### PR TITLE
use branch 'polkadot-v0.9.26'

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3709,6 +3709,23 @@ dependencies = [
 [[package]]
 name = "ias-verify"
 version = "0.1.4"
+source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.26#bd804ba63d4944952075b5fb8798066b8af87ab6"
+dependencies = [
+ "base64 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.22",
+ "frame-support",
+ "parity-scale-codec 3.1.5",
+ "scale-info",
+ "serde_json 1.0.83",
+ "sp-core",
+ "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.26)",
+ "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.26)",
+ "webpki 0.21.0",
+]
+
+[[package]]
+name = "ias-verify"
+version = "0.1.4"
 source = "git+https://github.com/integritee-network/pallets.git?branch=sdk-v0.9.0-polkadot-v0.9.26#170582c91c79cd5e2489e3e958aa27e26fce8bbc"
 dependencies = [
  "base64 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3898,7 +3915,7 @@ dependencies = [
  "substrate-api-client",
  "substrate-bip39",
  "substrate-client-keystore",
- "teerex-primitives",
+ "teerex-primitives 0.1.0 (git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.26)",
  "tiny-bip39",
  "ws",
 ]
@@ -3954,14 +3971,14 @@ dependencies = [
  "sgx_types",
  "sgx_urts",
  "sha2 0.7.1",
- "sidechain-primitives",
+ "sidechain-primitives 0.1.0 (git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.26)",
  "sidechain-test",
  "sp-core",
  "sp-finality-grandpa",
  "sp-keyring",
  "sp-runtime",
  "substrate-api-client",
- "teerex-primitives",
+ "teerex-primitives 0.1.0 (git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.26)",
  "thiserror 1.0.32",
  "tokio",
  "warp",
@@ -4130,7 +4147,7 @@ dependencies = [
  "rand 0.8.5",
  "sc-keystore",
  "sgx_tstd",
- "sidechain-primitives",
+ "sidechain-primitives 0.1.0 (git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.26)",
  "sp-application-crypto",
  "sp-core",
  "sp-io 6.0.0",
@@ -4367,7 +4384,7 @@ dependencies = [
  "log 0.4.17",
  "parity-scale-codec 3.1.5",
  "serde_json 1.0.83",
- "sidechain-primitives",
+ "sidechain-primitives 0.1.0 (git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.26)",
  "sidechain-test",
  "sp-core",
  "tokio",
@@ -4807,7 +4824,7 @@ dependencies = [
  "serde 1.0.143",
  "sgx_tstd",
  "sgx_types",
- "sidechain-primitives",
+ "sidechain-primitives 0.1.0 (git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.26)",
  "sp-application-crypto",
  "sp-core",
  "sp-runtime",
@@ -4849,7 +4866,7 @@ dependencies = [
 [[package]]
 name = "itp-types"
 version = "0.8.0"
-source = "git+https://github.com/integritee-network/pallets.git?branch=sdk-v0.9.0-polkadot-v0.9.26#170582c91c79cd5e2489e3e958aa27e26fce8bbc"
+source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.26#bd804ba63d4944952075b5fb8798066b8af87ab6"
 dependencies = [
  "chrono 0.4.22",
  "parity-scale-codec 3.1.5",
@@ -4866,7 +4883,7 @@ dependencies = [
 [[package]]
 name = "itp-utils"
 version = "0.8.0"
-source = "git+https://github.com/integritee-network/pallets.git?branch=sdk-v0.9.0-polkadot-v0.9.26#170582c91c79cd5e2489e3e958aa27e26fce8bbc"
+source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.26#bd804ba63d4944952075b5fb8798066b8af87ab6"
 dependencies = [
  "frame-support",
  "hex 0.4.3",
@@ -4894,7 +4911,7 @@ dependencies = [
  "parity-scale-codec 3.1.5",
  "sgx_tstd",
  "sgx_types",
- "sidechain-primitives",
+ "sidechain-primitives 0.1.0 (git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.26)",
  "sp-core",
  "sp-runtime",
  "thiserror 1.0.32",
@@ -4933,7 +4950,7 @@ dependencies = [
  "parity-scale-codec 3.1.5",
  "sgx_tstd",
  "sidechain-block-verification",
- "sidechain-primitives",
+ "sidechain-primitives 0.1.0 (git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.26)",
  "sidechain-test",
  "sp-core",
  "sp-keyring",
@@ -4958,7 +4975,7 @@ dependencies = [
  "sgx_tstd",
  "sgx_types",
  "sidechain-block-verification",
- "sidechain-primitives",
+ "sidechain-primitives 0.1.0 (git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.26)",
  "sidechain-test",
  "sp-core",
  "sp-keyring",
@@ -4985,7 +5002,7 @@ dependencies = [
  "parity-scale-codec 3.1.5",
  "sgx_tstd",
  "sidechain-block-verification",
- "sidechain-primitives",
+ "sidechain-primitives 0.1.0 (git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.26)",
  "sidechain-test",
  "sp-consensus-slots",
  "sp-keyring",
@@ -5008,7 +5025,7 @@ dependencies = [
  "log 0.4.17",
  "serde 1.0.143",
  "serde_json 1.0.83",
- "sidechain-primitives",
+ "sidechain-primitives 0.1.0 (git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.26)",
  "sidechain-test",
  "thiserror 1.0.32",
  "tokio",
@@ -5030,7 +5047,7 @@ dependencies = [
  "rust-base58 0.0.4 (git+https://github.com/mesalock-linux/rust-base58-sgx?rev=sgx_1.1.3)",
  "sgx_tstd",
  "sgx_types",
- "sidechain-primitives",
+ "sidechain-primitives 0.1.0 (git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.26)",
  "sp-core",
 ]
 
@@ -5046,7 +5063,7 @@ dependencies = [
  "its-state",
  "its-top-pool-executor",
  "its-validateer-fetch",
- "sidechain-primitives",
+ "sidechain-primitives 0.1.0 (git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.26)",
 ]
 
 [[package]]
@@ -5060,7 +5077,7 @@ dependencies = [
  "parity-scale-codec 3.1.5",
  "serde 1.0.143",
  "sgx_tstd",
- "sidechain-primitives",
+ "sidechain-primitives 0.1.0 (git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.26)",
  "sp-core",
  "sp-io 6.0.0",
  "sp-runtime",
@@ -5080,7 +5097,7 @@ dependencies = [
  "parity-scale-codec 3.1.5",
  "parking_lot 0.12.1",
  "rocksdb",
- "sidechain-primitives",
+ "sidechain-primitives 0.1.0 (git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.26)",
  "sidechain-test",
  "sp-core",
  "temp-dir",
@@ -5102,7 +5119,7 @@ dependencies = [
  "parity-scale-codec 3.1.5",
  "sgx_tstd",
  "sgx_types",
- "sidechain-primitives",
+ "sidechain-primitives 0.1.0 (git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.26)",
  "sp-core",
  "sp-runtime",
  "thiserror 1.0.32",
@@ -7875,7 +7892,7 @@ dependencies = [
  "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.26)",
  "sp-runtime",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.26)",
- "teerex-primitives",
+ "teerex-primitives 0.1.0 (git+https://github.com/integritee-network/pallets.git?branch=sdk-v0.9.0-polkadot-v0.9.26)",
 ]
 
 [[package]]
@@ -7997,7 +8014,7 @@ dependencies = [
 [[package]]
 name = "pallet-parentchain"
 version = "0.9.0"
-source = "git+https://github.com/integritee-network/pallets.git?branch=sdk-v0.9.0-polkadot-v0.9.26#170582c91c79cd5e2489e3e958aa27e26fce8bbc"
+source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.26#bd804ba63d4944952075b5fb8798066b8af87ab6"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8126,12 +8143,12 @@ dependencies = [
  "parity-scale-codec 3.1.5",
  "scale-info",
  "serde 1.0.143",
- "sidechain-primitives",
+ "sidechain-primitives 0.1.0 (git+https://github.com/integritee-network/pallets.git?branch=sdk-v0.9.0-polkadot-v0.9.26)",
  "sp-core",
  "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.26)",
  "sp-runtime",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.26)",
- "teerex-primitives",
+ "teerex-primitives 0.1.0 (git+https://github.com/integritee-network/pallets.git?branch=sdk-v0.9.0-polkadot-v0.9.26)",
 ]
 
 [[package]]
@@ -8206,7 +8223,7 @@ source = "git+https://github.com/integritee-network/pallets.git?branch=sdk-v0.9.
 dependencies = [
  "frame-support",
  "frame-system",
- "ias-verify",
+ "ias-verify 0.1.4 (git+https://github.com/integritee-network/pallets.git?branch=sdk-v0.9.0-polkadot-v0.9.26)",
  "log 0.4.17",
  "pallet-timestamp",
  "parity-scale-codec 3.1.5",
@@ -8216,7 +8233,7 @@ dependencies = [
  "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.26)",
  "sp-runtime",
  "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.26)",
- "teerex-primitives",
+ "teerex-primitives 0.1.0 (git+https://github.com/integritee-network/pallets.git?branch=sdk-v0.9.0-polkadot-v0.9.26)",
 ]
 
 [[package]]
@@ -8376,7 +8393,7 @@ dependencies = [
 [[package]]
 name = "parentchain-test"
 version = "0.8.0"
-source = "git+https://github.com/integritee-network/pallets.git?branch=sdk-v0.9.0-polkadot-v0.9.26#170582c91c79cd5e2489e3e958aa27e26fce8bbc"
+source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.26#bd804ba63d4944952075b5fb8798066b8af87ab6"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -12675,19 +12692,33 @@ checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 [[package]]
 name = "sidechain-block-verification"
 version = "0.9.0"
-source = "git+https://github.com/integritee-network/pallets.git?branch=sdk-v0.9.0-polkadot-v0.9.26#170582c91c79cd5e2489e3e958aa27e26fce8bbc"
+source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.26#bd804ba63d4944952075b5fb8798066b8af87ab6"
 dependencies = [
  "frame-support",
  "itp-types",
  "itp-utils",
  "log 0.4.17",
  "sgx_tstd",
- "sidechain-primitives",
+ "sidechain-primitives 0.1.0 (git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.26)",
  "sp-consensus-slots",
  "sp-core",
  "sp-runtime",
  "thiserror 1.0.32",
  "thiserror 1.0.9",
+]
+
+[[package]]
+name = "sidechain-primitives"
+version = "0.1.0"
+source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.26#bd804ba63d4944952075b5fb8798066b8af87ab6"
+dependencies = [
+ "parity-scale-codec 3.1.5",
+ "scale-info",
+ "serde 1.0.143",
+ "sp-core",
+ "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.26)",
+ "sp-runtime",
+ "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.26)",
 ]
 
 [[package]]
@@ -12707,11 +12738,11 @@ dependencies = [
 [[package]]
 name = "sidechain-test"
 version = "0.8.0"
-source = "git+https://github.com/integritee-network/pallets.git?branch=sdk-v0.9.0-polkadot-v0.9.26#170582c91c79cd5e2489e3e958aa27e26fce8bbc"
+source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.26#bd804ba63d4944952075b5fb8798066b8af87ab6"
 dependencies = [
  "itp-types",
  "parity-scale-codec 3.1.5",
- "sidechain-primitives",
+ "sidechain-primitives 0.1.0 (git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.26)",
  "sp-core",
 ]
 
@@ -13969,9 +14000,23 @@ dependencies = [
 [[package]]
 name = "teerex-primitives"
 version = "0.1.0"
+source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.26#bd804ba63d4944952075b5fb8798066b8af87ab6"
+dependencies = [
+ "ias-verify 0.1.4 (git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.26)",
+ "parity-scale-codec 3.1.5",
+ "scale-info",
+ "serde 1.0.143",
+ "sp-core",
+ "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.26)",
+ "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.26)",
+]
+
+[[package]]
+name = "teerex-primitives"
+version = "0.1.0"
 source = "git+https://github.com/integritee-network/pallets.git?branch=sdk-v0.9.0-polkadot-v0.9.26#170582c91c79cd5e2489e3e958aa27e26fce8bbc"
 dependencies = [
- "ias-verify",
+ "ias-verify 0.1.4 (git+https://github.com/integritee-network/pallets.git?branch=sdk-v0.9.0-polkadot-v0.9.26)",
  "parity-scale-codec 3.1.5",
  "scale-info",
  "serde 1.0.143",

--- a/app-libs/sgx-runtime/Cargo.toml
+++ b/app-libs/sgx-runtime/Cargo.toml
@@ -42,7 +42,7 @@ sp-transaction-pool = { default-features = false, git = "https://github.com/pari
 sp-version = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.26" }
 
 # Integritee dependencies
-pallet-parentchain = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.9.0-polkadot-v0.9.26" }
+pallet-parentchain = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "polkadot-v0.9.26" }
 pallet-evm = { default-features = false, optional = true, git = "https://github.com/integritee-network/frontier.git", branch = "polkadot-v0.9.26" }
 
 # Litentry

--- a/app-libs/stf/Cargo.toml
+++ b/app-libs/stf/Cargo.toml
@@ -35,9 +35,9 @@ sc-keystore = { optional = true, git = "https://github.com/paritytech/substrate.
 my-node-runtime = { package = "litmus-parachain-runtime", git = "https://github.com/litentry/litentry-parachain.git", branch = "tee-dev", optional = true }
 substrate-api-client = { git = "https://github.com/scs/substrate-api-client.git", branch = "polkadot-v0.9.26", optional = true }
 substrate-client-keystore = { git = "https://github.com/scs/substrate-api-client.git", branch = "polkadot-v0.9.26", optional = true }
-sidechain-primitives = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.9.0-polkadot-v0.9.26" }
-itp-types = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.9.0-polkadot-v0.9.26" }
-itp-utils = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.9.0-polkadot-v0.9.26" }
+sidechain-primitives = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "polkadot-v0.9.26" }
+itp-types = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "polkadot-v0.9.26" }
+itp-utils = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "polkadot-v0.9.26" }
 
 # litentry
 litentry-primitives = { path = "../../litentry-primitives" }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -27,12 +27,12 @@ hdrhistogram = "7.5.0"
 rand = "0.8.5"
 
 # scs / integritee
-itp-types = { git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.9.0-polkadot-v0.9.26" }
-itp-utils = { git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.9.0-polkadot-v0.9.26" }
+itp-types = { git = "https://github.com/integritee-network/pallets.git", branch = "polkadot-v0.9.26" }
+itp-utils = { git = "https://github.com/integritee-network/pallets.git", branch = "polkadot-v0.9.26" }
 my-node-runtime = { package = "litmus-parachain-runtime", git = "https://github.com/litentry/litentry-parachain.git", branch = "tee-dev" }
 substrate-api-client = { features = ["ws-client"], git = "https://github.com/scs/substrate-api-client.git", branch = "polkadot-v0.9.26" }
 substrate-client-keystore = { git = "https://github.com/scs/substrate-api-client.git", branch = "polkadot-v0.9.26" }
-teerex-primitives = { git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.9.0-polkadot-v0.9.26" }
+teerex-primitives = { git = "https://github.com/integritee-network/pallets.git", branch = "polkadot-v0.9.26" }
 
 # substrate dependencies
 sp-runtime = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.26" }

--- a/core-primitives/enclave-api/Cargo.toml
+++ b/core-primitives/enclave-api/Cargo.toml
@@ -23,7 +23,7 @@ itc-parentchain-light-client = { path = "../../core/parentchain/light-client" }
 itp-enclave-api-ffi = { path = "ffi" }
 itp-settings = { path = "../settings" }
 
-itp-types = { git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.9.0-polkadot-v0.9.26" }
+itp-types = { git = "https://github.com/integritee-network/pallets.git", branch = "polkadot-v0.9.26" }
 
 
 [dev-dependencies]

--- a/core-primitives/extrinsics-factory/Cargo.toml
+++ b/core-primitives/extrinsics-factory/Cargo.toml
@@ -16,7 +16,7 @@ itp-node-api = { path = "../node-api", default-features = false }
 itp-nonce-cache = { path = "../nonce-cache", default-features = false }
 
 # integritee
-itp-types = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.9.0-polkadot-v0.9.26" }
+itp-types = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "polkadot-v0.9.26" }
 
 # sgx enabled external libraries
 thiserror_sgx = { package = "thiserror", git = "https://github.com/mesalock-linux/thiserror-sgx", tag = "sgx_1.1.3", optional = true }

--- a/core-primitives/node-api/api-client-extensions/Cargo.toml
+++ b/core-primitives/node-api/api-client-extensions/Cargo.toml
@@ -18,7 +18,7 @@ sp-runtime = { git = "https://github.com/paritytech/substrate.git", branch = "po
 substrate-api-client = { git = "https://github.com/scs/substrate-api-client", branch = "polkadot-v0.9.26" }
 
 # integritee
-itp-types = { git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.9.0-polkadot-v0.9.26" }
+itp-types = { git = "https://github.com/integritee-network/pallets.git", branch = "polkadot-v0.9.26" }
 
 [features]
 # used for unit testing only!

--- a/core-primitives/node-api/metadata/Cargo.toml
+++ b/core-primitives/node-api/metadata/Cargo.toml
@@ -15,7 +15,7 @@ sp-core = { git = "https://github.com/paritytech/substrate.git", default-feature
 substrate-api-client = { default-features = false, git = "https://github.com/scs/substrate-api-client", branch = "polkadot-v0.9.26" }
 
 # integritee
-itp-types = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.9.0-polkadot-v0.9.26" }
+itp-types = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "polkadot-v0.9.26" }
 
 [features]
 default = ["std"]

--- a/core-primitives/ocall-api/Cargo.toml
+++ b/core-primitives/ocall-api/Cargo.toml
@@ -21,7 +21,7 @@ sp-std = { default-features = false, git = "https://github.com/paritytech/substr
 itp-storage = { path = "../storage", default-features = false }
 
 # integritee
-itp-types = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.9.0-polkadot-v0.9.26" }
+itp-types = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "polkadot-v0.9.26" }
 
 [features]
 default = ["std"]

--- a/core-primitives/rpc/Cargo.toml
+++ b/core-primitives/rpc/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0", default-features = false, features = ["alloc", "derive"] }
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
-itp-types = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.9.0-polkadot-v0.9.26" }
+itp-types = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "polkadot-v0.9.26" }
 
 # sgx deps
 sgx_tstd = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }

--- a/core-primitives/stf-executor/Cargo.toml
+++ b/core-primitives/stf-executor/Cargo.toml
@@ -12,7 +12,7 @@ sgx_tstd = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sd
 sgx-crypto-helper = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", package = "sgx_crypto_helper", default-features = false, optional = true }
 
 # integritee dependencies
-itp-types = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.9.0-polkadot-v0.9.26" }
+itp-types = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "polkadot-v0.9.26" }
 
 # local dependencies
 ita-stf = { path = "../../app-libs/stf", default-features = false }
@@ -43,7 +43,7 @@ sp-runtime = { default-features = false, git = "https://github.com/paritytech/su
 
 # dev dependencies
 itp-test = { path = "../test", default-features = false, optional = true }
-parentchain-test = { optional = true, default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.9.0-polkadot-v0.9.26" }
+parentchain-test = { optional = true, default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "polkadot-v0.9.26" }
 
 [features]
 default = ["std"]

--- a/core-primitives/stf-state-handler/Cargo.toml
+++ b/core-primitives/stf-state-handler/Cargo.toml
@@ -28,7 +28,7 @@ rust-base58 = { package = "rust-base58", version = "0.0.4", optional = true }
 thiserror = { version = "1.0", optional = true }
 
 # scs / integritee
-itp-types = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.9.0-polkadot-v0.9.26" }
+itp-types = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "polkadot-v0.9.26" }
 
 # no-std dependencies
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }

--- a/core-primitives/storage/Cargo.toml
+++ b/core-primitives/storage/Cargo.toml
@@ -24,7 +24,7 @@ sp-std = { default-features = false, git = "https://github.com/paritytech/substr
 sp-trie = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.26" }
 
 # integritee
-itp-types = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.9.0-polkadot-v0.9.26" }
+itp-types = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "polkadot-v0.9.26" }
 
 [dev-dependencies]
 sp-state-machine = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.26" }

--- a/core-primitives/test/Cargo.toml
+++ b/core-primitives/test/Cargo.toml
@@ -32,7 +32,7 @@ itp-teerex-storage = { path = "../teerex-storage", default-features = false }
 itp-time-utils = { path = "../time-utils", default-features = false }
 
 # integritee
-itp-types = { default-features = false, features = ["test"], git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.9.0-polkadot-v0.9.26" }
+itp-types = { default-features = false, features = ["test"], git = "https://github.com/integritee-network/pallets.git", branch = "polkadot-v0.9.26" }
 
 [features]
 default = ["std"]

--- a/core-primitives/top-pool-author/Cargo.toml
+++ b/core-primitives/top-pool-author/Cargo.toml
@@ -22,8 +22,8 @@ itp-test = { path = "../test", default-features = false, optional = true }
 itp-top-pool = { path = "../top-pool", default-features = false }
 
 # integritee
-itp-types = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.9.0-polkadot-v0.9.26" }
-itp-utils = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.9.0-polkadot-v0.9.26" }
+itp-types = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "polkadot-v0.9.26" }
+itp-utils = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "polkadot-v0.9.26" }
 
 # sgx enabled external libraries
 jsonrpc-core_sgx = { package = "jsonrpc-core", git = "https://github.com/scs/jsonrpc", branch = "no_std_v18", default-features = false, optional = true }

--- a/core-primitives/top-pool/Cargo.toml
+++ b/core-primitives/top-pool/Cargo.toml
@@ -15,7 +15,7 @@ ita-stf = { path = "../../app-libs/stf", default-features = false }
 itc-direct-rpc-server = { path = "../../core/direct-rpc-server", default-features = false }
 
 # integritee
-itp-types = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.9.0-polkadot-v0.9.26" }
+itp-types = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "polkadot-v0.9.26" }
 
 # sgx enabled external libraries
 jsonrpc-core_sgx = { package = "jsonrpc-core", git = "https://github.com/scs/jsonrpc", branch = "no_std_v18", default-features = false, optional = true }
@@ -36,7 +36,7 @@ serde = { version = "1.0", default-features = false, features = ["alloc", "deriv
 sp-application-crypto = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.26" }
 sp-core = { default-features = false, features = ["full_crypto"], git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.26" }
 sp-runtime = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.26" }
-sidechain-primitives = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.9.0-polkadot-v0.9.26" }
+sidechain-primitives = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "polkadot-v0.9.26" }
 
 # dev dependencies (for tests)
 [dev-dependencies]

--- a/core/direct-rpc-server/Cargo.toml
+++ b/core/direct-rpc-server/Cargo.toml
@@ -17,8 +17,8 @@ serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 sp-runtime = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.26" }
 
 # integritee dependencies
-itp-types = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.9.0-polkadot-v0.9.26" }
-itp-utils = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.9.0-polkadot-v0.9.26" }
+itp-types = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "polkadot-v0.9.26" }
+itp-utils = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "polkadot-v0.9.26" }
 
 # local
 itc-tls-websocket-server = { path = "../tls-websocket-server", default-features = false }

--- a/core/https-client-daemon/Cargo.toml
+++ b/core/https-client-daemon/Cargo.toml
@@ -23,7 +23,7 @@ lazy_static = {version = "1.1.0", features = ["spin_no_std"]}
 
 # internal dependencies
 itc-rest-client = { path = "../rest-client", default-features = false }
-itp-types = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.9.0-polkadot-v0.9.26" }
+itp-types = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "polkadot-v0.9.26" }
 
 itp-ocall-api = {path = "../../core-primitives/ocall-api", default-features = false }
 itp-extrinsics-factory = {path = "../../core-primitives/extrinsics-factory", default-features = false}

--- a/core/offchain-worker-executor/Cargo.toml
+++ b/core/offchain-worker-executor/Cargo.toml
@@ -27,7 +27,7 @@ itp-stf-state-handler = { path = "../../core-primitives/stf-state-handler", defa
 itp-top-pool-author = { path = "../../core-primitives/top-pool-author", default-features = false }
 
 # integritee
-itp-types = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.9.0-polkadot-v0.9.26" }
+itp-types = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "polkadot-v0.9.26" }
 
 # Substrate dependencies
 sp-core = { default-features = false, features = ["full_crypto"], git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.26" }

--- a/core/parentchain/block-import-dispatcher/Cargo.toml
+++ b/core/parentchain/block-import-dispatcher/Cargo.toml
@@ -25,7 +25,7 @@ log = { version = "0.4", default-features = false }
 sp-runtime = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.26" }
 
 [dev-dependencies]
-itp-types = { git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.9.0-polkadot-v0.9.26" }
+itp-types = { git = "https://github.com/integritee-network/pallets.git", branch = "polkadot-v0.9.26" }
 itc-parentchain-block-importer = { path = "../block-importer", features = ["mocks"] }
 
 [features]

--- a/core/parentchain/block-importer/Cargo.toml
+++ b/core/parentchain/block-importer/Cargo.toml
@@ -19,7 +19,7 @@ itp-settings = { path = "../../../core-primitives/settings" }
 itp-stf-executor = { path = "../../../core-primitives/stf-executor", default-features = false }
 
 # integritee
-itp-types = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.9.0-polkadot-v0.9.26" }
+itp-types = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "polkadot-v0.9.26" }
 
 # sgx enabled external libraries
 thiserror_sgx = { package = "thiserror", git = "https://github.com/mesalock-linux/thiserror-sgx", tag = "sgx_1.1.3", optional = true }

--- a/core/parentchain/indirect-calls-executor/Cargo.toml
+++ b/core/parentchain/indirect-calls-executor/Cargo.toml
@@ -38,7 +38,7 @@ sp-runtime = { default-features = false, git = "https://github.com/paritytech/su
 tiny-keccak = { version = "2.0.2", features = ["keccak"] }
 
 # scs/integritee
-itp-types = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.9.0-polkadot-v0.9.26" }
+itp-types = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "polkadot-v0.9.26" }
 substrate-api-client = { git = "https://github.com/scs/substrate-api-client", branch = "polkadot-v0.9.26", default-features = false }
 
 [dev-dependencies]
@@ -47,7 +47,7 @@ itp-sgx-crypto = { path = "../../../core-primitives/sgx/crypto", features = ["mo
 itp-stf-executor = { path = "../../../core-primitives/stf-executor", features = ["mocks"] }
 itp-test = { path = "../../../core-primitives/test" }
 itp-top-pool-author = { path = "../../../core-primitives/top-pool-author", features = ["mocks"] }
-parentchain-test = { git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.9.0-polkadot-v0.9.26" }
+parentchain-test = { git = "https://github.com/integritee-network/pallets.git", branch = "polkadot-v0.9.26" }
 
 [features]
 default = ["std"]

--- a/core/parentchain/light-client/Cargo.toml
+++ b/core/parentchain/light-client/Cargo.toml
@@ -26,7 +26,7 @@ itp-settings = { path = "../../../core-primitives/settings" }
 itp-storage = { path = "../../../core-primitives/storage", default-features = false }
 
 # integritee
-itp-types = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.9.0-polkadot-v0.9.26" }
+itp-types = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "polkadot-v0.9.26" }
 
 # substrate deps
 frame-system = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.26" }
@@ -37,7 +37,7 @@ sp-runtime = { default-features = false, git = "https://github.com/paritytech/su
 sp-trie = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.26" }
 
 # mocks dependencies
-parentchain-test = { optional = true, default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.9.0-polkadot-v0.9.26" }
+parentchain-test = { optional = true, default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "polkadot-v0.9.26" }
 
 [dev-dependencies]
 itp-test = { path = "../../../core-primitives/test" }

--- a/core/rpc-client/Cargo.toml
+++ b/core/rpc-client/Cargo.toml
@@ -19,8 +19,8 @@ url = { version = "2.0.0" }
 ws = { version = "0.9.1", features = ["ssl"] }
 
 # integritee
-itp-types = { git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.9.0-polkadot-v0.9.26" }
-itp-utils = { git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.9.0-polkadot-v0.9.26" }
+itp-types = { git = "https://github.com/integritee-network/pallets.git", branch = "polkadot-v0.9.26" }
+itp-utils = { git = "https://github.com/integritee-network/pallets.git", branch = "polkadot-v0.9.26" }
 
 # local
 itp-rpc = { path = "../../core-primitives/rpc" }

--- a/core/rpc-server/Cargo.toml
+++ b/core/rpc-server/Cargo.toml
@@ -14,8 +14,8 @@ tokio = { version = "1.6.1", features = ["full"] }
 parity-scale-codec = "3.0.0"
 
 # integritee deps
-itp-utils = { git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.9.0-polkadot-v0.9.26" }
-sidechain-primitives = { git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.9.0-polkadot-v0.9.26" }
+itp-utils = { git = "https://github.com/integritee-network/pallets.git", branch = "polkadot-v0.9.26" }
+sidechain-primitives = { git = "https://github.com/integritee-network/pallets.git", branch = "polkadot-v0.9.26" }
 
 # local
 itp-enclave-api = { path = "../../core-primitives/enclave-api" }
@@ -31,4 +31,4 @@ std = []
 [dev-dependencies]
 env_logger = { version = "*" }
 sp-core = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.26" }
-sidechain-test = { git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.9.0-polkadot-v0.9.26" }
+sidechain-test = { git = "https://github.com/integritee-network/pallets.git", branch = "polkadot-v0.9.26" }

--- a/enclave-runtime/Cargo.lock
+++ b/enclave-runtime/Cargo.lock
@@ -1908,7 +1908,7 @@ dependencies = [
 [[package]]
 name = "itp-types"
 version = "0.8.0"
-source = "git+https://github.com/integritee-network/pallets.git?branch=sdk-v0.9.0-polkadot-v0.9.26#170582c91c79cd5e2489e3e958aa27e26fce8bbc"
+source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.26#bd804ba63d4944952075b5fb8798066b8af87ab6"
 dependencies = [
  "chrono 0.4.22",
  "parity-scale-codec",
@@ -1925,7 +1925,7 @@ dependencies = [
 [[package]]
 name = "itp-utils"
 version = "0.8.0"
-source = "git+https://github.com/integritee-network/pallets.git?branch=sdk-v0.9.0-polkadot-v0.9.26#170582c91c79cd5e2489e3e958aa27e26fce8bbc"
+source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.26#bd804ba63d4944952075b5fb8798066b8af87ab6"
 dependencies = [
  "frame-support",
  "hex 0.4.3",
@@ -2565,7 +2565,7 @@ dependencies = [
 [[package]]
 name = "pallet-parentchain"
 version = "0.9.0"
-source = "git+https://github.com/integritee-network/pallets.git?branch=sdk-v0.9.0-polkadot-v0.9.26#170582c91c79cd5e2489e3e958aa27e26fce8bbc"
+source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.26#bd804ba63d4944952075b5fb8798066b8af87ab6"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2688,7 +2688,7 @@ dependencies = [
 [[package]]
 name = "parentchain-test"
 version = "0.8.0"
-source = "git+https://github.com/integritee-network/pallets.git?branch=sdk-v0.9.0-polkadot-v0.9.26#170582c91c79cd5e2489e3e958aa27e26fce8bbc"
+source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.26#bd804ba63d4944952075b5fb8798066b8af87ab6"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3619,7 +3619,7 @@ dependencies = [
 [[package]]
 name = "sidechain-block-verification"
 version = "0.9.0"
-source = "git+https://github.com/integritee-network/pallets.git?branch=sdk-v0.9.0-polkadot-v0.9.26#170582c91c79cd5e2489e3e958aa27e26fce8bbc"
+source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.26#bd804ba63d4944952075b5fb8798066b8af87ab6"
 dependencies = [
  "frame-support",
  "itp-types",
@@ -3636,7 +3636,7 @@ dependencies = [
 [[package]]
 name = "sidechain-primitives"
 version = "0.1.0"
-source = "git+https://github.com/integritee-network/pallets.git?branch=sdk-v0.9.0-polkadot-v0.9.26#170582c91c79cd5e2489e3e958aa27e26fce8bbc"
+source = "git+https://github.com/integritee-network/pallets.git?branch=polkadot-v0.9.26#bd804ba63d4944952075b5fb8798066b8af87ab6"
 dependencies = [
  "parity-scale-codec",
  "scale-info",

--- a/enclave-runtime/Cargo.toml
+++ b/enclave-runtime/Cargo.toml
@@ -55,13 +55,13 @@ hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
 ipfs-unixfs = { default-features = false, git = "https://github.com/whalelephant/rust-ipfs", branch = "w-nstd" }
 
 # scs / integritee
-itp-types = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.9.0-polkadot-v0.9.26" }
-itp-utils = { default-features = false, features = ["sgx"], git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.9.0-polkadot-v0.9.26" }
+itp-types = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "polkadot-v0.9.26" }
+itp-utils = { default-features = false, features = ["sgx"], git = "https://github.com/integritee-network/pallets.git", branch = "polkadot-v0.9.26" }
 jsonrpc-core = { default-features = false, git = "https://github.com/scs/jsonrpc", branch = "no_std_v18" }
-sidechain-primitives = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.9.0-polkadot-v0.9.26" }
+sidechain-primitives = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "polkadot-v0.9.26" }
 substrate-api-client = { default-features = false, git = "https://github.com/scs/substrate-api-client", branch = "polkadot-v0.9.26" }
-parentchain-test = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.9.0-polkadot-v0.9.26" }
-sidechain-block-verification = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.9.0-polkadot-v0.9.26"}
+parentchain-test = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "polkadot-v0.9.26" }
+sidechain-block-verification = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "polkadot-v0.9.26"}
 
 # mesalock
 linked-hash-map = { git = "https://github.com/mesalock-linux/linked-hash-map-sgx" }

--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -55,12 +55,12 @@ its-rpc-handler = { path = "../sidechain/rpc-handler" }
 its-storage = { path = "../sidechain/storage" }
 
 # scs / integritee
-itp-types = { git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.9.0-polkadot-v0.9.26" }
-itp-utils = { git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.9.0-polkadot-v0.9.26" }
+itp-types = { git = "https://github.com/integritee-network/pallets.git", branch = "polkadot-v0.9.26" }
+itp-utils = { git = "https://github.com/integritee-network/pallets.git", branch = "polkadot-v0.9.26" }
 my-node-runtime = { package = "litmus-parachain-runtime", git = "https://github.com/litentry/litentry-parachain.git", branch = "tee-dev" }
-sidechain-primitives = { git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.9.0-polkadot-v0.9.26" }
+sidechain-primitives = { git = "https://github.com/integritee-network/pallets.git", branch = "polkadot-v0.9.26" }
 substrate-api-client = { git = "https://github.com/scs/substrate-api-client.git", branch = "polkadot-v0.9.26" }
-teerex-primitives = { git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.9.0-polkadot-v0.9.26" }
+teerex-primitives = { git = "https://github.com/integritee-network/pallets.git", branch = "polkadot-v0.9.26" }
 
 # Substrate dependencies
 sp-runtime = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.26" }
@@ -86,5 +86,5 @@ mockall = "0.11"
 # local
 itp-test = { path = "../core-primitives/test" }
 its-peer-fetch = { path = "../sidechain/peer-fetch", features = ["mocks"] }
-parentchain-test = { git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.9.0-polkadot-v0.9.26" }
-sidechain-test = { git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.9.0-polkadot-v0.9.26" }
+parentchain-test = { git = "https://github.com/integritee-network/pallets.git", branch = "polkadot-v0.9.26" }
+sidechain-test = { git = "https://github.com/integritee-network/pallets.git", branch = "polkadot-v0.9.26" }

--- a/sidechain/block-composer/Cargo.toml
+++ b/sidechain/block-composer/Cargo.toml
@@ -21,8 +21,8 @@ itp-top-pool-author = { path = "../../core-primitives/top-pool-author", default-
 its-state = { path = "../state", default-features = false }
 
 # integritee dependencies
-itp-types = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.9.0-polkadot-v0.9.26" }
-sidechain-primitives = { default-features = false, features = ["full_crypto"], git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.9.0-polkadot-v0.9.26" }
+itp-types = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "polkadot-v0.9.26" }
+sidechain-primitives = { default-features = false, features = ["full_crypto"], git = "https://github.com/integritee-network/pallets.git", branch = "polkadot-v0.9.26" }
 
 # sgx enabled external libraries
 thiserror_sgx = { package = "thiserror", git = "https://github.com/mesalock-linux/thiserror-sgx", tag = "sgx_1.1.3", optional = true }

--- a/sidechain/consensus/aura/Cargo.toml
+++ b/sidechain/consensus/aura/Cargo.toml
@@ -6,11 +6,11 @@ edition = "2018"
 
 [dependencies]
 finality-grandpa = { version = "0.16.0", default-features = false, features = ["derive-codec"] }
-itp-types = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.9.0-polkadot-v0.9.26" }
-itp-utils = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.9.0-polkadot-v0.9.26" }
+itp-types = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "polkadot-v0.9.26" }
+itp-utils = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "polkadot-v0.9.26" }
 log = { version = "0.4", default-features = false }
-sidechain-primitives = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.9.0-polkadot-v0.9.26" }
-sidechain-block-verification = { optional = true, default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.9.0-polkadot-v0.9.26" }
+sidechain-primitives = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "polkadot-v0.9.26" }
+sidechain-block-verification = { optional = true, default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "polkadot-v0.9.26" }
 
 # sgx deps
 sgx_tstd = { branch = "master", git = "https://github.com/apache/teaclave-sgx-sdk.git", optional = true }
@@ -45,8 +45,8 @@ itc-parentchain-block-import-dispatcher = { path = "../../../core/parentchain/bl
 itp-storage = { path = "../../../core-primitives/storage" }
 itp-test = { path = "../../../core-primitives/test" }
 its-top-pool-executor = { path = "../../top-pool-executor", features = ["mocks"] }
-parentchain-test = { git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.9.0-polkadot-v0.9.26" }
-sidechain-test = { git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.9.0-polkadot-v0.9.26" }
+parentchain-test = { git = "https://github.com/integritee-network/pallets.git", branch = "polkadot-v0.9.26" }
+sidechain-test = { git = "https://github.com/integritee-network/pallets.git", branch = "polkadot-v0.9.26" }
 sp-keyring = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.26" }
 
 [features]

--- a/sidechain/consensus/common/Cargo.toml
+++ b/sidechain/consensus/common/Cargo.toml
@@ -24,17 +24,17 @@ thiserror-sgx = { package = "thiserror", optional = true, git = "https://github.
 sp-runtime = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.26" }
 
 # scs / integritee
-itp-types = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.9.0-polkadot-v0.9.26" }
-sidechain-block-verification = { optional = true, default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.9.0-polkadot-v0.9.26" }
-sidechain-primitives = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.9.0-polkadot-v0.9.26" }
+itp-types = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "polkadot-v0.9.26" }
+sidechain-block-verification = { optional = true, default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "polkadot-v0.9.26" }
+sidechain-primitives = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "polkadot-v0.9.26" }
 
 [dev-dependencies]
 # local
 itp-sgx-externalities = { default-features = false, path = "../../../core-primitives/substrate-sgx/externalities" }
 itp-test = { path = "../../../core-primitives/test" }
 its-consensus-aura = { path = "../aura" }
-parentchain-test = { git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.9.0-polkadot-v0.9.26" }
-sidechain-test = { git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.9.0-polkadot-v0.9.26" }
+parentchain-test = { git = "https://github.com/integritee-network/pallets.git", branch = "polkadot-v0.9.26" }
+sidechain-test = { git = "https://github.com/integritee-network/pallets.git", branch = "polkadot-v0.9.26" }
 
 # substrate
 sp-core = { default-features = false, features = ["full_crypto"], git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.26" }

--- a/sidechain/consensus/slots/Cargo.toml
+++ b/sidechain/consensus/slots/Cargo.toml
@@ -12,9 +12,9 @@ derive_more = "0.99.16"
 lazy_static = { version = "1.1.0", features = ["spin_no_std"] }
 
 # scs / integritee
-itp-types = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.9.0-polkadot-v0.9.26" }
-sidechain-block-verification = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.9.0-polkadot-v0.9.26"}
-sidechain-primitives = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.9.0-polkadot-v0.9.26" }
+itp-types = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "polkadot-v0.9.26" }
+sidechain-block-verification = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "polkadot-v0.9.26"}
+sidechain-primitives = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "polkadot-v0.9.26" }
 
 # only for slot-stream
 futures = { version = "0.3", optional = true }
@@ -34,8 +34,8 @@ itp-time-utils = { path = "../../../core-primitives/time-utils", default-feature
 its-consensus-common = { path = "../common", default-features = false }
 
 [dev-dependencies]
-parentchain-test = { git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.9.0-polkadot-v0.9.26" }
-sidechain-test = { git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.9.0-polkadot-v0.9.26" }
+parentchain-test = { git = "https://github.com/integritee-network/pallets.git", branch = "polkadot-v0.9.26" }
+sidechain-test = { git = "https://github.com/integritee-network/pallets.git", branch = "polkadot-v0.9.26" }
 sp-keyring = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.26" }
 tokio = "*"
 

--- a/sidechain/peer-fetch/Cargo.toml
+++ b/sidechain/peer-fetch/Cargo.toml
@@ -16,7 +16,7 @@ thiserror = { version = "1.0" }
 tokio = { version = "1.6.1", features = ["full"] }
 
 # scs / integritee
-sidechain-primitives = { git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.9.0-polkadot-v0.9.26" }
+sidechain-primitives = { git = "https://github.com/integritee-network/pallets.git", branch = "polkadot-v0.9.26" }
 
 # local
 itc-rpc-client = { path = "../../core/rpc-client" }
@@ -31,7 +31,7 @@ anyhow = "1.0.40"
 itp-node-api = { path = "../../core-primitives/node-api", features = ["mocks"] }
 itp-test = { path = "../../core-primitives/test" }
 its-storage = { path = "../storage", features = ["mocks"] }
-sidechain-test = { git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.9.0-polkadot-v0.9.26" }
+sidechain-test = { git = "https://github.com/integritee-network/pallets.git", branch = "polkadot-v0.9.26" }
 
 [features]
 default = ["std"]

--- a/sidechain/rpc-handler/Cargo.toml
+++ b/sidechain/rpc-handler/Cargo.toml
@@ -28,9 +28,9 @@ log = { version = "0.4", default-features = false }
 sp-core = { default-features = false, features = ["full_crypto"], git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.26" }
 
 # scs / integritee
-itp-types = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.9.0-polkadot-v0.9.26" }
-itp-utils = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.9.0-polkadot-v0.9.26" }
-sidechain-primitives = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.9.0-polkadot-v0.9.26" }
+itp-types = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "polkadot-v0.9.26" }
+itp-utils = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "polkadot-v0.9.26" }
+sidechain-primitives = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "polkadot-v0.9.26" }
 
 [features]
 default = ["std"]

--- a/sidechain/sidechain-crate/Cargo.toml
+++ b/sidechain/sidechain-crate/Cargo.toml
@@ -37,4 +37,4 @@ its-state = { path = "../state", default-features = false }
 its-top-pool-executor = { path = "../top-pool-executor", default-features = false }
 its-validateer-fetch = { path = "../validateer-fetch", default-features = false }
 
-sidechain-primitives = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.9.0-polkadot-v0.9.26" }
+sidechain-primitives = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "polkadot-v0.9.26" }

--- a/sidechain/state/Cargo.toml
+++ b/sidechain/state/Cargo.toml
@@ -25,7 +25,7 @@ itp-storage = { path = "../../core-primitives/storage", default-features = false
 sp-io = { optional = true, default-features = false, features = ["disable_oom", "disable_panic_handler", "disable_allocator"], path = "../../core-primitives/substrate-sgx/sp-io" }
 
 # scs deps
-sidechain-primitives = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.9.0-polkadot-v0.9.26" }
+sidechain-primitives = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "polkadot-v0.9.26" }
 
 # substrate deps
 sp-core = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.26" }

--- a/sidechain/storage/Cargo.toml
+++ b/sidechain/storage/Cargo.toml
@@ -13,8 +13,8 @@ rocksdb = { version = "0.18.0", default_features = false }
 thiserror = "1.0"
 
 # integritee
-itp-types = { git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.9.0-polkadot-v0.9.26" }
-sidechain-primitives = { git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.9.0-polkadot-v0.9.26" }
+itp-types = { git = "https://github.com/integritee-network/pallets.git", branch = "polkadot-v0.9.26" }
+sidechain-primitives = { git = "https://github.com/integritee-network/pallets.git", branch = "polkadot-v0.9.26" }
 
 # Substrate dependencies
 sp-core = { git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.26" }
@@ -24,7 +24,7 @@ sp-core = { git = "https://github.com/paritytech/substrate.git", branch = "polka
 mockall = "0.11"
 temp-dir = "0.1"
 # local
-sidechain-test = { git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.9.0-polkadot-v0.9.26" }
+sidechain-test = { git = "https://github.com/integritee-network/pallets.git", branch = "polkadot-v0.9.26" }
 itp-time-utils = { path = "../../core-primitives/time-utils" }
 
 [features]

--- a/sidechain/top-pool-executor/Cargo.toml
+++ b/sidechain/top-pool-executor/Cargo.toml
@@ -19,8 +19,8 @@ itp-top-pool-author = { path = "../../core-primitives/top-pool-author", default-
 its-state = { path = "../state", default-features = false }
 
 # integritee dependencies
-itp-types = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.9.0-polkadot-v0.9.26" }
-sidechain-primitives = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.9.0-polkadot-v0.9.26" }
+itp-types = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "polkadot-v0.9.26" }
+sidechain-primitives = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "polkadot-v0.9.26" }
 
 # sgx enabled external libraries
 thiserror_sgx = { package = "thiserror", git = "https://github.com/mesalock-linux/thiserror-sgx", tag = "sgx_1.1.3", optional = true }

--- a/sidechain/validateer-fetch/Cargo.toml
+++ b/sidechain/validateer-fetch/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 derive_more = "0.99.16"
 thiserror = "1.0.26"
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive", "chain-error"] }
-itp-types = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.9.0-polkadot-v0.9.26" }
+itp-types = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "polkadot-v0.9.26" }
 
 # substrate deps
 frame-support = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.26" }
@@ -35,4 +35,4 @@ std = [
 
 [dev-dependencies]
 itp-test = { path = "../../core-primitives/test" }
-parentchain-test = { git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.9.0-polkadot-v0.9.26" }
+parentchain-test = { git = "https://github.com/integritee-network/pallets.git", branch = "polkadot-v0.9.26" }


### PR DESCRIPTION
It's better to use branch "polkadot-v0.9.26", which is the typical branch naming convention for newer polkadot updates.
info: https://github.com/integritee-network/pallets/tree/polkadot-v0.9.26 

Also solves #23  #24 