### PR TITLE
Use AES in IMT-pallet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6198,7 +6198,11 @@ checksum = "d4d2456c373231a208ad294c33dc5bff30051eafd954cd4caae83a712b12854d"
 
 [[package]]
 name = "litentry-primitives"
-version = "0.8.0"
+version = "0.1.0"
+dependencies = [
+ "parity-scale-codec 3.1.5",
+ "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.26)",
+]
 
 [[package]]
 name = "litmus-parachain-runtime"
@@ -7850,6 +7854,7 @@ dependencies = [
  "frame-support",
  "frame-system",
  "hex 0.4.3",
+ "litentry-primitives",
  "log 0.4.17",
  "pallet-balances",
  "parity-scale-codec 3.1.5",

--- a/app-libs/sgx-runtime/src/lib.rs
+++ b/app-libs/sgx-runtime/src/lib.rs
@@ -69,12 +69,9 @@ pub use pallet_timestamp::Call as TimestampCall;
 pub use sp_runtime::BuildStorage;
 pub use sp_runtime::{Perbill, Permill};
 
-pub use pallet_identity_management;
+pub use pallet_identity_management::{self, Call as IdentityManagementCall};
 /// litentry
-pub use pallet_sgx_account_linker;
-pub use pallet_sgx_account_linker::Call as SgxAccountLinkerCall;
-pub type UserShieldingKey = pallet_identity_management::UserShieldingKeyOf<Runtime>;
-pub use pallet_identity_management::Call as IdentityManagementCall;
+pub use pallet_sgx_account_linker::{self, Call as SgxAccountLinkerCall};
 
 /// The address format for describing accounts.
 pub type Address = sp_runtime::MultiAddress<AccountId, ()>;
@@ -307,7 +304,6 @@ impl pallet_identity_management::Config for Runtime {
 	type Event = Event;
 	type ManageOrigin = EnsureRoot<AccountId>;
 	type ChallengeCode = u32;
-	type MaxUserShieldingKeyLength = ConstU32<1024>;
 	type MaxDidLength = ConstU32<128>;
 	type MaxMetadataLength = ConstU32<128>;
 	type MaxVerificationDelay = ConstU32<2>;

--- a/app-libs/stf/Cargo.toml
+++ b/app-libs/stf/Cargo.toml
@@ -40,7 +40,7 @@ itp-types = { default-features = false, git = "https://github.com/integritee-net
 itp-utils = { default-features = false, git = "https://github.com/integritee-network/pallets.git", branch = "sdk-v0.9.0-polkadot-v0.9.26" }
 
 # litentry
-litentry-primitives = { path = "../../litentry-primitives" }
+litentry-primitives = { path = "../../litentry-primitives", default-features = false }
 itc-https-client-daemon = { path = "../../core/https-client-daemon", default-features = false, features = ["sgx"], optional = true }
 hex-sgx = { package = "hex", git = "https://github.com/mesalock-linux/rust-hex-sgx", tag = "sgx_1.1.3", features = ["sgx_tstd"] }
 pallet-sgx-account-linker = { path = "../../litentry/pallets/account-linker", default-features = false }

--- a/app-libs/stf/src/helpers.rs
+++ b/app-libs/stf/src/helpers.rs
@@ -18,10 +18,9 @@ use crate::{
 	stf_sgx_primitives::types::*, AccountId, Index, StfError, StfResult, ENCLAVE_ACCOUNT_KEY, H256,
 };
 use codec::{Decode, Encode};
-use ita_sgx_runtime::UserShieldingKey;
 use itp_storage::{storage_double_map_key, storage_map_key, storage_value_key, StorageHasher};
 use itp_utils::stringify::account_id_to_string;
-use litentry_primitives::eth::EthAddress;
+use litentry_primitives::{eth::EthAddress, UserShieldingKeyType};
 use log::*;
 use pallet_sgx_account_linker::LinkedSubAccount;
 use std::prelude::v1::*;
@@ -93,7 +92,7 @@ pub fn get_account_info(who: &AccountId) -> Option<AccountInfo> {
 }
 
 /// Litentry
-pub fn get_shielding_key(who: &AccountId) -> Option<UserShieldingKey> {
+pub fn get_shielding_key(who: &AccountId) -> Option<UserShieldingKeyType> {
 	get_storage_map(
 		"IdentityManagement",
 		"UserShieldingKeys",

--- a/app-libs/stf/src/lib.rs
+++ b/app-libs/stf/src/lib.rs
@@ -26,7 +26,6 @@
 #[cfg(all(not(feature = "std"), feature = "sgx"))]
 extern crate sgx_tstd as std;
 
-use ita_sgx_runtime::UserShieldingKey;
 #[cfg(feature = "sgx")]
 pub use ita_sgx_runtime::{Balance, BlockNumber, Index};
 #[cfg(feature = "std")]
@@ -36,7 +35,7 @@ use codec::{Compact, Decode, Encode};
 use derive_more::Display;
 use litentry_primitives::{
 	eth::{EthAddress, EthSignature},
-	LinkingAccountIndex,
+	LinkingAccountIndex, UserShieldingKeyType,
 };
 use sp_core::{crypto::AccountId32, ed25519, sr25519, Pair, H256};
 use sp_runtime::{traits::Verify, MultiSignature};
@@ -193,7 +192,7 @@ pub enum TrustedCall {
 	balance_unshield(AccountId, AccountId, Balance, ShardIdentifier), // (AccountIncognito, BeneficiaryPublicAccount, Amount, Shard)
 	balance_shield(AccountId, AccountId, Balance), // (Root, AccountIncognito, Amount)
 	// litentry
-	set_shielding_key(AccountId, AccountId, UserShieldingKey), // (Root, AccountIncognito, Key)
+	set_shielding_key(AccountId, AccountId, UserShieldingKeyType), // (Root, AccountIncognito, Key)
 	link_eth(AccountId, LinkingAccountIndex, EthAddress, BlockNumber, EthSignature), // (LitentryAcc, EthAcc Index, EthAcc, ParentchainBlockNr, Signature)
 	link_sub(
 		AccountId,

--- a/app-libs/stf/src/stf_sgx_litentry.rs
+++ b/app-libs/stf/src/stf_sgx_litentry.rs
@@ -16,7 +16,7 @@
 
 use crate::{
 	helpers::{get_linked_ethereum_addresses, get_parentchain_number},
-	stf_sgx_primitives::{litentry::*, types::*},
+	stf_sgx_primitives::types::*,
 	AccountId, StfError, StfResult,
 };
 #[cfg(all(not(feature = "std"), feature = "sgx"))]
@@ -25,7 +25,7 @@ use codec::Encode;
 use ita_sgx_runtime::Runtime;
 use litentry_primitives::{
 	eth::{EthAddress, EthSignature},
-	LinkingAccountIndex,
+	LinkingAccountIndex, UserShieldingKeyType,
 };
 use log::*;
 
@@ -38,7 +38,7 @@ use itc_https_client_daemon::daemon_sender::SendHttpsRequest;
 use itp_utils::stringify::account_id_to_string;
 
 impl Stf {
-	pub fn set_shielding_key(who: AccountId, key: UserShieldingKey) -> StfResult<()> {
+	pub fn set_shielding_key(who: AccountId, key: UserShieldingKeyType) -> StfResult<()> {
 		debug!("who.str = {:?}, key = {:?}", account_id_to_string(&who), key.clone());
 		ita_sgx_runtime::IdentityManagementCall::<Runtime>::set_user_shielding_key { who, key }
 			.dispatch_bypass_filter(ita_sgx_runtime::Origin::root())

--- a/app-libs/stf/src/stf_sgx_litentry.rs
+++ b/app-libs/stf/src/stf_sgx_litentry.rs
@@ -15,9 +15,7 @@
 // along with Litentry.  If not, see <https://www.gnu.org/licenses/>.
 
 use crate::{
-	helpers::{get_linked_ethereum_addresses, get_parentchain_number},
-	stf_sgx_primitives::types::*,
-	AccountId, StfError, StfResult,
+	helpers::get_parentchain_number, stf_sgx_primitives::types::*, AccountId, StfError, StfResult,
 };
 #[cfg(all(not(feature = "std"), feature = "sgx"))]
 extern crate sgx_tstd as std;

--- a/app-libs/stf/src/stf_sgx_primitives.rs
+++ b/app-libs/stf/src/stf_sgx_primitives.rs
@@ -43,11 +43,6 @@ pub mod types {
 	pub struct Stf;
 }
 
-/// the litentry primitives
-pub mod litentry {
-	pub use ita_sgx_runtime::UserShieldingKey;
-}
-
 use types::StateTypeDiff;
 
 /// Payload to be sent to peers for a state update.

--- a/cli/src/trusted_commands.rs
+++ b/cli/src/trusted_commands.rs
@@ -25,14 +25,16 @@ use crate::{
 };
 use codec::Decode;
 use hdrhistogram::Histogram;
-pub use ita_sgx_runtime::UserShieldingKey;
 use ita_stf::{Index, KeyPair, TrustedCall, TrustedGetter, TrustedOperation};
 use itc_rpc_client::direct_client::{DirectApi, DirectClient};
 use itp_types::{
 	TrustedOperationStatus,
 	TrustedOperationStatus::{InSidechainBlock, Submitted},
 };
-use litentry_primitives::{eth::EthAddress, LinkingAccountIndex};
+pub use litentry_primitives::{
+	eth::{EthAddress, EthSignature},
+	LinkingAccountIndex, UserShieldingKeyType,
+};
 use log::*;
 pub use my_node_runtime::{Balance, BlockNumber};
 use pallet_sgx_account_linker::LinkedSubAccount;
@@ -183,8 +185,8 @@ pub enum TrustedCommands {
 		/// AccountId in ss58check format
 		account: String,
 
-		/// Shielding key
-		key: String,
+		/// Shielding key in hex string
+		key_hex: String,
 	},
 
 	/// Get a shielding key for a given account
@@ -254,8 +256,8 @@ pub fn match_trusted_commands(cli: &Cli, trusted_args: &TrustedArgs) {
 			funding_account,
 		),
 		// Litentry
-		TrustedCommands::SetShieldingKey { account, key } =>
-			set_shielding_key(cli, trusted_args, account, key),
+		TrustedCommands::SetShieldingKey { account, key_hex } =>
+			set_shielding_key(cli, trusted_args, account, key_hex),
 		TrustedCommands::ShieldingKey { account } => shielding_key(cli, trusted_args, account),
 		TrustedCommands::LinkedEthAddresses { account } =>
 			linked_eth_addresses(cli, trusted_args, account),

--- a/cli/src/trusted_commands_litentry.rs
+++ b/cli/src/trusted_commands_litentry.rs
@@ -61,7 +61,7 @@ pub(crate) fn shielding_key(cli: &Cli, trusted_args: &TrustedArgs, arg_who: &str
 		.into();
 	let key = perform_operation(cli, trusted_args, &top)
 		.and_then(|v| UserShieldingKeyType::decode(&mut v.as_slice()).ok());
-	println!("{:?}", hex::encode(&key.unwrap()));
+	println!("{}", hex::encode(&key.unwrap()));
 }
 
 pub(crate) fn linked_eth_addresses(cli: &Cli, trusted_args: &TrustedArgs, arg_who: &str) {

--- a/cli/src/trusted_commands_litentry.rs
+++ b/cli/src/trusted_commands_litentry.rs
@@ -20,24 +20,25 @@ use crate::{
 	get_layer_two_nonce,
 	trusted_command_utils::{get_accountid_from_str, get_identifiers, get_pair_from_str},
 	trusted_commands::{
-		perform_operation, BlockNumber, LinkedEthereumAddress, LinkedSubstrateAddress, TrustedArgs,
-		UserShieldingKey,
+		perform_operation, BlockNumber, EthAddress, EthSignature, LinkedEthereumAddress,
+		LinkedSubstrateAddress, LinkingAccountIndex, TrustedArgs, UserShieldingKeyType,
 	},
 	Cli,
 };
 use codec::Decode;
 use ita_stf::{Index, KeyPair, TrustedCall, TrustedGetter, TrustedOperation};
-use litentry_primitives::{
-	eth::{EthAddress, EthSignature},
-	LinkingAccountIndex,
-};
 use log::*;
 use pallet_sgx_account_linker::{MultiSignature, NetworkType};
 use sp_application_crypto::Ss58Codec;
 use sp_core::{sr25519 as sr25519_core, Pair};
 
-pub(crate) fn set_shielding_key(cli: &Cli, trusted_args: &TrustedArgs, arg_who: &str, key: &str) {
-	warn!("arg_who = {:?}, key = {:?}", arg_who, key);
+pub(crate) fn set_shielding_key(
+	cli: &Cli,
+	trusted_args: &TrustedArgs,
+	arg_who: &str,
+	key_hex: &str,
+) {
+	warn!("arg_who = {:?}, key = {:?}", arg_who, key_hex);
 	let who = get_pair_from_str(trusted_args, arg_who);
 	let root = get_pair_from_str(trusted_args, "//Alice");
 
@@ -45,13 +46,12 @@ pub(crate) fn set_shielding_key(cli: &Cli, trusted_args: &TrustedArgs, arg_who: 
 
 	let (mrenclave, shard) = get_identifiers(trusted_args);
 	let nonce = get_layer_two_nonce!(root, cli, trusted_args);
-	let top: TrustedOperation = TrustedCall::set_shielding_key(
-		root.public().into(),
-		who.public().into(),
-		key.as_bytes().to_vec().try_into().unwrap(),
-	)
-	.sign(&KeyPair::Sr25519(root), nonce, &mrenclave, &shard)
-	.into_trusted_operation(trusted_args.direct);
+	let mut key = [0u8; 32];
+	let _ = hex::decode_to_slice(key_hex, &mut key).expect("decoding key failed");
+	let top: TrustedOperation =
+		TrustedCall::set_shielding_key(root.public().into(), who.public().into(), key)
+			.sign(&KeyPair::Sr25519(root), nonce, &mrenclave, &shard)
+			.into_trusted_operation(trusted_args.direct);
 	let _ = perform_operation(cli, trusted_args, &top);
 }
 
@@ -62,8 +62,8 @@ pub(crate) fn shielding_key(cli: &Cli, trusted_args: &TrustedArgs, arg_who: &str
 		.sign(&KeyPair::Sr25519(who))
 		.into();
 	let key = perform_operation(cli, trusted_args, &top)
-		.and_then(|v| UserShieldingKey::decode(&mut v.as_slice()).ok());
-	println!("{}", String::from_utf8(key.unwrap().into_inner()).unwrap());
+		.and_then(|v| UserShieldingKeyType::decode(&mut v.as_slice()).ok());
+	println!("{:?}", key.unwrap());
 }
 
 pub(crate) fn linked_eth_addresses(cli: &Cli, trusted_args: &TrustedArgs, arg_who: &str) {

--- a/cli/src/trusted_commands_litentry.rs
+++ b/cli/src/trusted_commands_litentry.rs
@@ -14,8 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with Litentry.  If not, see <https://www.gnu.org/licenses/>.
 
-use std::convert::TryInto;
-
 use crate::{
 	get_layer_two_nonce,
 	trusted_command_utils::{get_accountid_from_str, get_identifiers, get_pair_from_str},
@@ -63,7 +61,7 @@ pub(crate) fn shielding_key(cli: &Cli, trusted_args: &TrustedArgs, arg_who: &str
 		.into();
 	let key = perform_operation(cli, trusted_args, &top)
 		.and_then(|v| UserShieldingKeyType::decode(&mut v.as_slice()).ok());
-	println!("{:?}", key.unwrap());
+	println!("{:?}", hex::encode(&key.unwrap()));
 }
 
 pub(crate) fn linked_eth_addresses(cli: &Cli, trusted_args: &TrustedArgs, arg_who: &str) {

--- a/cli/user_shielding_key.sh
+++ b/cli/user_shielding_key.sh
@@ -41,7 +41,7 @@ echo "Using trusted-worker uri $WORKER1URL:$WORKER1PORT"
 echo ""
 
 ICGACCOUNTALICE=//AliceIncognito
-KEY="abcdefd/+23one"
+KEY="22fc82db5b606998ad45099b7978b5b4f9dd4ea6017e57370ac56141caaabd12"
 
 CLIENT="$CLIENT_BIN -p $NPORT -P $WORKER1PORT -u $NODEURL -U $WORKER1URL"
 echo "CLIENT is $CLIENT"
@@ -90,7 +90,7 @@ else
 fi
 
 # change KEY
-KEY="abcdefd/+23two"
+KEY="8378193a4ce64180814bd60591d1054a04dbc4da02afde453799cd6888ee0c6c"
 
 # indirect calls
 sleep 10

--- a/enclave-runtime/Cargo.lock
+++ b/enclave-runtime/Cargo.lock
@@ -2228,7 +2228,11 @@ dependencies = [
 
 [[package]]
 name = "litentry-primitives"
-version = "0.8.0"
+version = "0.1.0"
+dependencies = [
+ "parity-scale-codec",
+ "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.26)",
+]
 
 [[package]]
 name = "log"
@@ -2553,6 +2557,7 @@ dependencies = [
  "frame-support",
  "frame-system",
  "hex 0.4.3",
+ "litentry-primitives",
  "log",
  "parity-scale-codec",
  "scale-info",

--- a/enclave-runtime/src/test/tests_main.rs
+++ b/enclave-runtime/src/test/tests_main.rs
@@ -822,6 +822,7 @@ fn test_call_link_sub_ed25519() {
 	Stf::execute(&mut state, signed_call, &mut dummy_vec, [0u8, 1u8]).unwrap();
 }
 
+#[allow(dead_code)]
 fn test_call_link_sub_ecdsa() {
 	// init test environment
 	let (_, mut state, shard, mrenclave, _, _) = test_setup();

--- a/litentry-primitives/Cargo.toml
+++ b/litentry-primitives/Cargo.toml
@@ -1,8 +1,16 @@
 [package]
 name = "litentry-primitives"
-version = "0.8.0"
-authors = ["Litentry Technologies GmbH <info@litentry.com>"]
-edition = "2018"
+version = "0.1.0"
+authors = ["Litentry Dev"]
+edition = "2021"
+
+[dependencies]
+codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
+sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.26", default-features = false }
 
 [features]
+default = ["std"]
+std = [
+    "sp-std/std",
+]
 production = []

--- a/litentry-primitives/src/lib.rs
+++ b/litentry-primitives/src/lib.rs
@@ -1,15 +1,50 @@
-//! litentry primitives. It is strictly `no_std`
+// Copyright 2020-2022 Litentry Technologies GmbH.
+// This file is part of Litentry.
+//
+// Litentry is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Litentry is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Litentry.  If not, see <https://www.gnu.org/licenses/>.
 
-#![no_std]
+#![cfg_attr(not(feature = "std"), no_std)]
+use codec::{Decode, Encode};
+use sp_std::vec::Vec;
 
-// FIXME: is this the right place for this definition?
-//        @Han: Yes it's the correct place.
+// TODO: is this the best place for it?
+//       putting it in ita-stf would cause cyclic dependencies
+//       alternatively we could put it into IMT pallet
+//
+// we use 256-bit AES-GCM as user shielding key
+pub const USER_SHIELDING_KEY_LEN: usize = 32;
+pub const USER_SHIELDING_KEY_NONCE_LEN: usize = 12;
+pub const USER_SHIELDING_KEY_TAG_LEN: usize = 16;
+
+pub type UserShieldingKeyType = [u8; USER_SHIELDING_KEY_LEN];
+
+// all-in-one struct containing the encrypted ciphertext with user's
+// shielding key and other metadata that is required for decryption
+//
+// by default a postfix tag is used => last 16 bytes of ciphertext is MAC tag
+#[derive(Debug, Default, Clone, Eq, PartialEq, Encode, Decode)]
+pub struct AesOutput {
+	ciphertext: Vec<u8>,
+	aad: Vec<u8>,
+	nonce: [u8; USER_SHIELDING_KEY_NONCE_LEN], // IV
+}
+
+// deprecated - to be removed
 pub type LinkingAccountIndex = u32;
 
+// deprecated - to be removed
 pub mod eth {
-	// FIXME: these should be imported from a general crate (currently defined in the account linker pallet)
-	//        @Han: This is a good point. We need to have a primitive crate outside worker
 	pub type EthAddress = [u8; 20];
-	// rsv signature
 	pub type EthSignature = [u8; 65];
 }

--- a/litentry-primitives/src/lib.rs
+++ b/litentry-primitives/src/lib.rs
@@ -18,9 +18,7 @@
 use codec::{Decode, Encode};
 use sp_std::vec::Vec;
 
-// TODO: is this the best place for it?
-//       putting it in ita-stf would cause cyclic dependencies
-//       alternatively we could put it into IMT pallet
+// TODO: import the const and struct from the parachain once the code is there
 //
 // we use 256-bit AES-GCM as user shielding key
 pub const USER_SHIELDING_KEY_LEN: usize = 32;

--- a/litentry/pallets/identity-management/Cargo.toml
+++ b/litentry/pallets/identity-management/Cargo.toml
@@ -25,6 +25,8 @@ serde = { version = "1.0", default-features = false, features = ["derive", "allo
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 serde_derive = { version = "1.0", default-features = false }
 
+litentry-primitives = { path = "../../../litentry-primitives", default-features = false }
+
 [dev-dependencies]
 pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.26", default-features = false }
 

--- a/litentry/pallets/identity-management/src/lib.rs
+++ b/litentry/pallets/identity-management/src/lib.rs
@@ -38,10 +38,8 @@ pub mod identity_context;
 use frame_support::{pallet_prelude::*, traits::StorageVersion};
 use frame_system::pallet_prelude::*;
 use identity_context::IdentityContext;
+pub use litentry_primitives::UserShieldingKeyType;
 
-// TODO: maybe use sgx_crypto_helper::rsa3072::Rsa3072PubKey and implement traits for it
-
-pub type UserShieldingKeyOf<T> = BoundedVec<u8, <T as Config>::MaxUserShieldingKeyLength>;
 pub type ChallengeCodeOf<T> = <T as Config>::ChallengeCode;
 pub type DidOf<T> = BoundedVec<u8, <T as Config>::MaxDidLength>;
 pub(crate) type BlockNumberOf<T> = <T as frame_system::Config>::BlockNumber;
@@ -67,9 +65,6 @@ pub mod pallet {
 		type ManageOrigin: EnsureOrigin<Self::Origin>;
 		/// challenge code type
 		type ChallengeCode: Member + Parameter + Default + Copy + MaxEncodedLen;
-		/// maximum user shielding key length
-		#[pallet::constant]
-		type MaxUserShieldingKeyLength: Get<u32>;
 		/// maximum did length
 		#[pallet::constant]
 		type MaxDidLength: Get<u32>;
@@ -85,7 +80,7 @@ pub mod pallet {
 	#[pallet::generate_deposit(pub(super) fn deposit_event)]
 	pub enum Event<T: Config> {
 		/// user shielding key was set
-		UserShieldingKeySet { who: T::AccountId, key: UserShieldingKeyOf<T> },
+		UserShieldingKeySet { who: T::AccountId, key: UserShieldingKeyType },
 		/// challenge code was set
 		ChallengeCodeSet { who: T::AccountId, did: DidOf<T>, code: ChallengeCodeOf<T> },
 		/// challenge code was removed
@@ -114,7 +109,7 @@ pub mod pallet {
 	#[pallet::storage]
 	#[pallet::getter(fn user_shielding_keys)]
 	pub type UserShieldingKeys<T: Config> =
-		StorageMap<_, Blake2_128Concat, T::AccountId, UserShieldingKeyOf<T>, OptionQuery>;
+		StorageMap<_, Blake2_128Concat, T::AccountId, UserShieldingKeyType, OptionQuery>;
 
 	/// challenge code is per Litentry account + did
 	#[pallet::storage]
@@ -148,7 +143,7 @@ pub mod pallet {
 		pub fn set_user_shielding_key(
 			origin: OriginFor<T>,
 			who: T::AccountId,
-			key: UserShieldingKeyOf<T>,
+			key: UserShieldingKeyType,
 		) -> DispatchResult {
 			T::ManageOrigin::ensure_origin(origin)?;
 			// we don't care about the current key

--- a/litentry/pallets/identity-management/src/mock.rs
+++ b/litentry/pallets/identity-management/src/mock.rs
@@ -95,7 +95,6 @@ impl pallet_tee_identity_management::Config for Test {
 	type Event = Event;
 	type ManageOrigin = EnsureSignedBy<One, u64>;
 	type ChallengeCode = u32;
-	type MaxUserShieldingKeyLength = ConstU32<1024>;
 	type MaxDidLength = ConstU32<128>;
 	type MaxMetadataLength = ConstU32<128>;
 	type MaxVerificationDelay = ConstU64<2>;

--- a/litentry/pallets/identity-management/src/tests.rs
+++ b/litentry/pallets/identity-management/src/tests.rs
@@ -16,14 +16,15 @@
 
 use crate::{
 	identity_context::IdentityContext, mock::*, BlockNumberOf, DidOf, Error, MetadataOf,
-	UserShieldingKeyOf,
+	UserShieldingKeyType,
 };
 use frame_support::{assert_noop, assert_ok};
+use litentry_primitives::USER_SHIELDING_KEY_LEN;
 
 #[test]
 fn set_user_shielding_key_works() {
 	new_test_ext().execute_with(|| {
-		let shielding_key: UserShieldingKeyOf<Test> = vec![0u8; 384].try_into().unwrap();
+		let shielding_key: UserShieldingKeyType = [0u8; USER_SHIELDING_KEY_LEN];
 		assert_eq!(IMT::user_shielding_keys(2), None);
 		assert_ok!(IMT::set_user_shielding_key(Origin::signed(1), 2, shielding_key.clone()));
 		assert_eq!(IMT::user_shielding_keys(2), Some(shielding_key.clone()));


### PR DESCRIPTION
resolves #57 

switch to AES-GCM key type (32-byte fixed u8) as the user's shielding key, and some clean-ups