### PR TITLE
run tee-worker with remote attestation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,7 +23,7 @@ dependencies = [
  "sp-application-crypto",
  "sp-core",
  "sp-runtime",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
 ]
 
 [[package]]
@@ -46,7 +46,7 @@ dependencies = [
  "sp-core",
  "sp-runtime",
  "sp-runtime-interface",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
 ]
 
 [[package]]
@@ -58,7 +58,7 @@ dependencies = [
  "parity-scale-codec",
  "sp-core",
  "sp-runtime",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
 ]
 
 [[package]]
@@ -683,7 +683,7 @@ dependencies = [
  "sp-application-crypto",
  "sp-core",
  "sp-runtime",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
 ]
 
 [[package]]
@@ -1294,7 +1294,7 @@ name = "common-primitives"
 version = "0.1.0"
 source = "git+https://github.com/integritee-network/pallets.git?branch=develop#ee5a5b8b4fabb520d75f18ad808251341eee4169"
 dependencies = [
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
 ]
 
 [[package]]
@@ -1651,7 +1651,7 @@ dependencies = [
  "sp-application-crypto",
  "sp-consensus-aura",
  "sp-runtime",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
 ]
 
 [[package]]
@@ -1667,7 +1667,7 @@ dependencies = [
  "scale-info",
  "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
  "sp-runtime",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
  "xcm",
  "xcm-executor",
 ]
@@ -1697,7 +1697,7 @@ dependencies = [
  "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
  "sp-runtime",
  "sp-state-machine",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
  "sp-trie",
  "sp-version",
  "xcm",
@@ -1727,7 +1727,7 @@ dependencies = [
  "serde 1.0.147",
  "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
  "sp-runtime",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
  "xcm",
 ]
 
@@ -1744,7 +1744,7 @@ dependencies = [
  "rand_chacha 0.3.1",
  "scale-info",
  "sp-runtime",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
  "xcm",
  "xcm-executor",
 ]
@@ -1761,7 +1761,7 @@ dependencies = [
  "polkadot-primitives",
  "sp-api",
  "sp-runtime",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
  "sp-trie",
 ]
 
@@ -1782,7 +1782,7 @@ dependencies = [
  "sp-inherents",
  "sp-runtime",
  "sp-state-machine",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
  "sp-storage",
  "sp-trie",
  "tracing",
@@ -1797,7 +1797,7 @@ dependencies = [
  "futures 0.3.25",
  "parity-scale-codec",
  "sp-inherents",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
  "sp-timestamp",
 ]
 
@@ -1814,7 +1814,7 @@ dependencies = [
  "polkadot-parachain",
  "polkadot-primitives",
  "sp-runtime",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
  "sp-trie",
  "xcm",
  "xcm-builder",
@@ -1854,7 +1854,7 @@ dependencies = [
  "polkadot-primitives",
  "sp-runtime",
  "sp-state-machine",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
 ]
 
 [[package]]
@@ -2736,7 +2736,7 @@ dependencies = [
  "parity-scale-codec",
  "serde 1.0.147",
  "sp-core",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
 ]
 
 [[package]]
@@ -2763,7 +2763,7 @@ dependencies = [
  "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
  "sp-runtime",
  "sp-runtime-interface",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
  "sp-storage",
 ]
 
@@ -2842,7 +2842,7 @@ dependencies = [
  "sp-arithmetic",
  "sp-npos-elections",
  "sp-runtime",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
 ]
 
 [[package]]
@@ -2857,7 +2857,7 @@ dependencies = [
  "sp-core",
  "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
  "sp-runtime",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
  "sp-tracing",
 ]
 
@@ -2910,7 +2910,7 @@ dependencies = [
  "sp-runtime",
  "sp-staking",
  "sp-state-machine",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
  "sp-tracing",
  "tt-call",
 ]
@@ -2962,7 +2962,7 @@ dependencies = [
  "sp-core",
  "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
  "sp-runtime",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
  "sp-version",
 ]
 
@@ -2978,7 +2978,7 @@ dependencies = [
  "scale-info",
  "sp-core",
  "sp-runtime",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
 ]
 
 [[package]]
@@ -2998,7 +2998,7 @@ dependencies = [
  "frame-support",
  "sp-api",
  "sp-runtime",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
 ]
 
 [[package]]
@@ -3861,7 +3861,7 @@ dependencies = [
  "serde_json 1.0.87",
  "sp-core",
  "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
  "webpki 0.21.0",
 ]
 
@@ -4263,7 +4263,7 @@ dependencies = [
  "sp-core",
  "sp-inherents",
  "sp-runtime",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
  "sp-version",
 ]
 
@@ -4471,7 +4471,7 @@ dependencies = [
  "sp-core",
  "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
  "sp-runtime",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
 ]
 
 [[package]]
@@ -4802,7 +4802,7 @@ dependencies = [
  "sgx_types",
  "sp-core",
  "sp-runtime",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
 ]
 
 [[package]]
@@ -4978,7 +4978,7 @@ dependencies = [
  "sp-core",
  "sp-runtime",
  "sp-state-machine",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
  "sp-trie",
  "thiserror 1.0.37",
  "thiserror 1.0.9",
@@ -4989,7 +4989,7 @@ name = "itp-teerex-storage"
 version = "0.9.0"
 dependencies = [
  "itp-storage",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
 ]
 
 [[package]]
@@ -5014,7 +5014,7 @@ dependencies = [
  "sgx_types",
  "sp-core",
  "sp-runtime",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
 ]
 
 [[package]]
@@ -5094,7 +5094,7 @@ dependencies = [
  "serde_json 1.0.87",
  "sp-core",
  "sp-runtime",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
 ]
 
 [[package]]
@@ -5282,7 +5282,7 @@ dependencies = [
  "sp-core",
  "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
  "sp-runtime",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
 ]
 
 [[package]]
@@ -5334,7 +5334,7 @@ dependencies = [
  "sp-core",
  "sp-io 6.0.0",
  "sp-runtime",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
  "thiserror 1.0.37",
  "thiserror 1.0.9",
 ]
@@ -5383,7 +5383,7 @@ dependencies = [
  "parity-scale-codec",
  "sp-core",
  "sp-runtime",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
  "thiserror 1.0.37",
 ]
 
@@ -5423,14 +5423,13 @@ dependencies = [
 [[package]]
 name = "jsonrpc-core"
 version = "18.0.0"
-source = "git+https://github.com/scs/jsonrpc?branch=no_std_v18#eb7cdf49c0e5d35174f972743a7e3ff460aadedc"
+source = "git+https://github.com/scs/jsonrpc?branch=no_std_v18#0faf53c491c3222b96242a973d902dd06e9b6674"
 dependencies = [
  "futures 0.3.8",
  "log 0.4.14 (git+https://github.com/mesalock-linux/log-sgx)",
  "serde 1.0.118 (git+https://github.com/mesalock-linux/serde-sgx)",
  "serde_derive 1.0.118",
  "serde_json 1.0.60 (git+https://github.com/mesalock-linux/serde-json-sgx)",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=master)",
 ]
 
 [[package]]
@@ -5852,7 +5851,7 @@ dependencies = [
  "sp-core",
  "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
  "sp-runtime",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
  "thiserror 1.0.37",
  "thiserror 1.0.9",
  "url 2.1.1",
@@ -5916,7 +5915,7 @@ dependencies = [
  "sgx_tstd",
  "sp-core",
  "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
  "thiserror 1.0.37",
  "thiserror 1.0.9",
  "url 2.1.1",
@@ -5977,7 +5976,7 @@ dependencies = [
  "serde_json 1.0.87",
  "sgx_tstd",
  "sp-core",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
  "thiserror 1.0.37",
  "thiserror 1.0.9",
  "url 2.1.1",
@@ -6005,7 +6004,7 @@ dependencies = [
  "serde_json 1.0.87",
  "sgx_tstd",
  "sp-runtime",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
  "thiserror 1.0.37",
  "thiserror 1.0.9",
  "url 2.1.1",
@@ -6717,7 +6716,7 @@ dependencies = [
  "sgx_tstd",
  "sp-core",
  "sp-runtime",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
 ]
 
 [[package]]
@@ -7067,7 +7066,7 @@ dependencies = [
  "serde_json 1.0.87",
  "sp-core",
  "sp-runtime",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
 ]
 
 [[package]]
@@ -7809,7 +7808,7 @@ dependencies = [
  "scale-info",
  "serde 1.0.147",
  "sp-runtime",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
 ]
 
 [[package]]
@@ -7826,7 +7825,7 @@ dependencies = [
  "serde 1.0.147",
  "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
  "sp-runtime",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
  "xcm",
 ]
 
@@ -7841,7 +7840,7 @@ dependencies = [
  "serde 1.0.147",
  "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
  "sp-runtime",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
 ]
 
 [[package]]
@@ -7853,7 +7852,7 @@ dependencies = [
  "orml-traits",
  "parity-scale-codec",
  "sp-runtime",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
  "xcm",
  "xcm-executor",
 ]
@@ -7874,7 +7873,7 @@ dependencies = [
  "serde 1.0.147",
  "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
  "sp-runtime",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
  "xcm",
  "xcm-executor",
 ]
@@ -7911,7 +7910,7 @@ dependencies = [
  "smallvec 1.10.0",
  "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
  "sp-runtime",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
  "xcm",
 ]
 
@@ -7928,7 +7927,7 @@ dependencies = [
  "sp-application-crypto",
  "sp-consensus-aura",
  "sp-runtime",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
 ]
 
 [[package]]
@@ -7944,7 +7943,7 @@ dependencies = [
  "sp-application-crypto",
  "sp-authority-discovery",
  "sp-runtime",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
 ]
 
 [[package]]
@@ -7959,7 +7958,7 @@ dependencies = [
  "scale-info",
  "sp-authorship",
  "sp-runtime",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
 ]
 
 [[package]]
@@ -7983,7 +7982,7 @@ dependencies = [
  "sp-runtime",
  "sp-session",
  "sp-staking",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
 ]
 
 [[package]]
@@ -7998,7 +7997,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-runtime",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
 ]
 
 [[package]]
@@ -8013,7 +8012,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-runtime",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
 ]
 
 [[package]]
@@ -8029,7 +8028,7 @@ dependencies = [
  "scale-info",
  "serde 1.0.147",
  "sp-runtime",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
 ]
 
 [[package]]
@@ -8052,7 +8051,7 @@ dependencies = [
  "sp-core",
  "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
  "sp-runtime",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
 ]
 
 [[package]]
@@ -8069,7 +8068,7 @@ dependencies = [
  "sp-core",
  "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
  "sp-runtime",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
 ]
 
 [[package]]
@@ -8087,7 +8086,7 @@ dependencies = [
  "sp-core",
  "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
  "sp-runtime",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
 ]
 
 [[package]]
@@ -8107,7 +8106,7 @@ dependencies = [
  "sp-core",
  "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
  "sp-runtime",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
 ]
 
 [[package]]
@@ -8125,7 +8124,7 @@ dependencies = [
  "sp-core",
  "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
  "sp-runtime",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
 ]
 
 [[package]]
@@ -8142,7 +8141,7 @@ dependencies = [
  "sp-core",
  "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
  "sp-runtime",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
 ]
 
 [[package]]
@@ -8158,7 +8157,7 @@ dependencies = [
  "serde 1.0.147",
  "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
  "sp-runtime",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
 ]
 
 [[package]]
@@ -8173,7 +8172,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-runtime",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
 ]
 
 [[package]]
@@ -8194,7 +8193,7 @@ dependencies = [
  "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
  "sp-npos-elections",
  "sp-runtime",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
  "static_assertions",
  "strum",
 ]
@@ -8213,7 +8212,7 @@ dependencies = [
  "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
  "sp-npos-elections",
  "sp-runtime",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
 ]
 
 [[package]]
@@ -8237,7 +8236,7 @@ dependencies = [
  "sp-core",
  "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
  "sp-runtime",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
 ]
 
 [[package]]
@@ -8251,7 +8250,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-runtime",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
 ]
 
 [[package]]
@@ -8274,7 +8273,7 @@ dependencies = [
  "sp-runtime",
  "sp-session",
  "sp-staking",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
 ]
 
 [[package]]
@@ -8290,7 +8289,7 @@ dependencies = [
  "scale-info",
  "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
  "sp-runtime",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
 ]
 
 [[package]]
@@ -8312,7 +8311,7 @@ dependencies = [
  "sp-core",
  "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
  "sp-runtime",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
 ]
 
 [[package]]
@@ -8331,7 +8330,7 @@ dependencies = [
  "sp-arithmetic",
  "sp-core",
  "sp-runtime",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
 ]
 
 [[package]]
@@ -8357,7 +8356,7 @@ dependencies = [
  "sp-core",
  "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
  "sp-runtime",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
 ]
 
 [[package]]
@@ -8376,7 +8375,7 @@ dependencies = [
  "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
  "sp-runtime",
  "sp-staking",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
 ]
 
 [[package]]
@@ -8392,7 +8391,7 @@ dependencies = [
  "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
  "sp-keyring",
  "sp-runtime",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
 ]
 
 [[package]]
@@ -8409,7 +8408,7 @@ dependencies = [
  "sp-core",
  "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
  "sp-runtime",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
 ]
 
 [[package]]
@@ -8427,7 +8426,7 @@ dependencies = [
  "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
  "sp-mmr-primitives",
  "sp-runtime",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
 ]
 
 [[package]]
@@ -8456,7 +8455,7 @@ dependencies = [
  "scale-info",
  "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
  "sp-runtime",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
 ]
 
 [[package]]
@@ -8473,7 +8472,7 @@ dependencies = [
  "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
  "sp-runtime",
  "sp-staking",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
 ]
 
 [[package]]
@@ -8490,7 +8489,7 @@ dependencies = [
  "serde 1.0.147",
  "sp-runtime",
  "sp-staking",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
 ]
 
 [[package]]
@@ -8511,7 +8510,7 @@ dependencies = [
  "serde 1.0.147",
  "sp-runtime",
  "sp-staking",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
  "substrate-fixed 0.5.9 (git+https://github.com/encointer/substrate-fixed)",
 ]
 
@@ -8529,7 +8528,7 @@ dependencies = [
  "sp-core",
  "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
  "sp-runtime",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
 ]
 
 [[package]]
@@ -8545,7 +8544,7 @@ dependencies = [
  "sp-core",
  "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
  "sp-runtime",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
 ]
 
 [[package]]
@@ -8559,7 +8558,7 @@ dependencies = [
  "scale-info",
  "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
  "sp-runtime",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
 ]
 
 [[package]]
@@ -8575,7 +8574,7 @@ dependencies = [
  "scale-info",
  "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
  "sp-runtime",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
 ]
 
 [[package]]
@@ -8595,7 +8594,7 @@ dependencies = [
  "sp-runtime",
  "sp-session",
  "sp-staking",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
  "sp-trie",
 ]
 
@@ -8616,7 +8615,7 @@ dependencies = [
  "sp-core",
  "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
  "sp-runtime",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
  "teerex-primitives",
 ]
 
@@ -8638,7 +8637,7 @@ dependencies = [
  "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
  "sp-runtime",
  "sp-staking",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
 ]
 
 [[package]]
@@ -8663,7 +8662,7 @@ dependencies = [
  "scale-info",
  "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
  "sp-runtime",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
 ]
 
 [[package]]
@@ -8680,7 +8679,7 @@ dependencies = [
  "sp-core",
  "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
  "sp-runtime",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
  "substrate-fixed 0.5.9 (git+https://github.com/encointer/substrate-fixed?tag=v0.5.9)",
  "teeracle-primitives",
 ]
@@ -8701,7 +8700,7 @@ dependencies = [
  "sp-core",
  "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
  "sp-runtime",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
  "teerex-primitives",
 ]
 
@@ -8719,7 +8718,7 @@ dependencies = [
  "sp-inherents",
  "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
  "sp-runtime",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
  "sp-timestamp",
 ]
 
@@ -8738,7 +8737,7 @@ dependencies = [
  "sp-core",
  "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
  "sp-runtime",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
 ]
 
 [[package]]
@@ -8754,7 +8753,7 @@ dependencies = [
  "sp-core",
  "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
  "sp-runtime",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
 ]
 
 [[package]]
@@ -8796,7 +8795,7 @@ dependencies = [
  "scale-info",
  "serde 1.0.147",
  "sp-runtime",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
 ]
 
 [[package]]
@@ -8811,7 +8810,7 @@ dependencies = [
  "sp-core",
  "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
  "sp-runtime",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
 ]
 
 [[package]]
@@ -8830,7 +8829,7 @@ dependencies = [
  "sp-arithmetic",
  "sp-core",
  "sp-runtime",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
 ]
 
 [[package]]
@@ -8844,7 +8843,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-runtime",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
 ]
 
 [[package]]
@@ -8860,7 +8859,7 @@ dependencies = [
  "serde 1.0.147",
  "sp-core",
  "sp-runtime",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
  "xcm",
  "xcm-executor",
 ]
@@ -9404,7 +9403,7 @@ dependencies = [
  "scale-info",
  "sp-core",
  "sp-runtime",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
 ]
 
 [[package]]
@@ -9941,7 +9940,7 @@ dependencies = [
  "serde 1.0.147",
  "sp-core",
  "sp-runtime",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
 ]
 
 [[package]]
@@ -9969,7 +9968,7 @@ dependencies = [
  "sp-keystore",
  "sp-runtime",
  "sp-staking",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
  "sp-trie",
  "sp-version",
 ]
@@ -10076,7 +10075,7 @@ dependencies = [
  "sp-runtime",
  "sp-session",
  "sp-staking",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
  "sp-transaction-pool",
  "sp-version",
  "static_assertions",
@@ -10126,7 +10125,7 @@ dependencies = [
  "sp-runtime",
  "sp-session",
  "sp-staking",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
  "static_assertions",
  "xcm",
 ]
@@ -10151,7 +10150,7 @@ dependencies = [
  "bs58",
  "parity-scale-codec",
  "polkadot-primitives",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
  "sp-tracing",
 ]
 
@@ -10190,7 +10189,7 @@ dependencies = [
  "sp-runtime",
  "sp-session",
  "sp-staking",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
  "xcm",
  "xcm-executor",
 ]
@@ -10461,7 +10460,7 @@ dependencies = [
  "scale-info",
  "sp-core",
  "sp-runtime",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
 ]
 
 [[package]]
@@ -11190,7 +11189,7 @@ dependencies = [
  "sp-offchain",
  "sp-runtime",
  "sp-session",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
  "sp-transaction-pool",
  "sp-version",
  "substrate-wasm-builder",
@@ -11282,7 +11281,7 @@ dependencies = [
  "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
  "sp-runtime",
  "sp-state-machine",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
  "xcm",
  "xcm-builder",
  "xcm-executor",
@@ -12378,7 +12377,7 @@ dependencies = [
  "serde_json 1.0.87",
  "sp-core",
  "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
 ]
 
 [[package]]
@@ -13095,7 +13094,7 @@ dependencies = [
  "sp-core",
  "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
  "sp-runtime",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
 ]
 
 [[package]]
@@ -13183,7 +13182,7 @@ dependencies = [
  "parity-scale-codec",
  "paste",
  "sp-runtime",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
 ]
 
 [[package]]
@@ -13296,7 +13295,7 @@ dependencies = [
  "sp-core",
  "sp-runtime",
  "sp-state-machine",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
  "sp-version",
  "thiserror 1.0.37",
 ]
@@ -13323,7 +13322,7 @@ dependencies = [
  "serde 1.0.147",
  "sp-core",
  "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
 ]
 
 [[package]]
@@ -13337,7 +13336,7 @@ dependencies = [
  "scale-info",
  "serde 1.0.147",
  "sp-debug-derive",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
  "static_assertions",
 ]
 
@@ -13351,7 +13350,7 @@ dependencies = [
  "sp-api",
  "sp-application-crypto",
  "sp-runtime",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
 ]
 
 [[package]]
@@ -13363,7 +13362,7 @@ dependencies = [
  "parity-scale-codec",
  "sp-inherents",
  "sp-runtime",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
 ]
 
 [[package]]
@@ -13375,7 +13374,7 @@ dependencies = [
  "sp-api",
  "sp-inherents",
  "sp-runtime",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
 ]
 
 [[package]]
@@ -13410,7 +13409,7 @@ dependencies = [
  "sp-inherents",
  "sp-runtime",
  "sp-state-machine",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
  "sp-version",
  "thiserror 1.0.37",
 ]
@@ -13429,7 +13428,7 @@ dependencies = [
  "sp-consensus-slots",
  "sp-inherents",
  "sp-runtime",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
  "sp-timestamp",
 ]
 
@@ -13452,7 +13451,7 @@ dependencies = [
  "sp-inherents",
  "sp-keystore",
  "sp-runtime",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
  "sp-timestamp",
 ]
 
@@ -13466,7 +13465,7 @@ dependencies = [
  "serde 1.0.147",
  "sp-arithmetic",
  "sp-runtime",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
  "sp-timestamp",
 ]
 
@@ -13480,7 +13479,7 @@ dependencies = [
  "schnorrkel",
  "sp-core",
  "sp-runtime",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
 ]
 
 [[package]]
@@ -13519,7 +13518,7 @@ dependencies = [
  "sp-debug-derive",
  "sp-externalities",
  "sp-runtime-interface",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
  "sp-storage",
  "ss58-registry",
  "substrate-bip39",
@@ -13539,7 +13538,7 @@ dependencies = [
  "digest 0.10.5",
  "sha2 0.10.6",
  "sha3",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
  "twox-hash",
 ]
 
@@ -13580,7 +13579,7 @@ source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.2
 dependencies = [
  "environmental 1.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-scale-codec",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
  "sp-storage",
 ]
 
@@ -13599,7 +13598,7 @@ dependencies = [
  "sp-core",
  "sp-keystore",
  "sp-runtime",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
 ]
 
 [[package]]
@@ -13612,7 +13611,7 @@ dependencies = [
  "parity-scale-codec",
  "sp-core",
  "sp-runtime",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
  "thiserror 1.0.37",
 ]
 
@@ -13632,7 +13631,7 @@ dependencies = [
  "sgx_types",
  "sp-core",
  "sp-runtime-interface",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
  "sp-tracing",
  "sp-wasm-interface",
  "tracing",
@@ -13657,7 +13656,7 @@ dependencies = [
  "sp-keystore",
  "sp-runtime-interface",
  "sp-state-machine",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
  "sp-tracing",
  "sp-trie",
  "sp-wasm-interface",
@@ -13714,7 +13713,7 @@ dependencies = [
  "sp-core",
  "sp-debug-derive",
  "sp-runtime",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
 ]
 
 [[package]]
@@ -13728,7 +13727,7 @@ dependencies = [
  "sp-arithmetic",
  "sp-core",
  "sp-runtime",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
 ]
 
 [[package]]
@@ -13780,7 +13779,7 @@ dependencies = [
  "sp-arithmetic",
  "sp-core",
  "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
 ]
 
 [[package]]
@@ -13794,7 +13793,7 @@ dependencies = [
  "primitive-types",
  "sp-externalities",
  "sp-runtime-interface-proc-macro",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
  "sp-storage",
  "sp-tracing",
  "sp-wasm-interface",
@@ -13822,7 +13821,7 @@ dependencies = [
  "parity-scale-codec",
  "sp-core",
  "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
  "sp-wasm-interface",
  "wasmi",
 ]
@@ -13838,7 +13837,7 @@ dependencies = [
  "sp-core",
  "sp-runtime",
  "sp-staking",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
 ]
 
 [[package]]
@@ -13849,7 +13848,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-runtime",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
 ]
 
 [[package]]
@@ -13867,17 +13866,12 @@ dependencies = [
  "sp-core",
  "sp-externalities",
  "sp-panic-handler",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
  "sp-trie",
  "thiserror 1.0.37",
  "tracing",
  "trie-root",
 ]
-
-[[package]]
-name = "sp-std"
-version = "4.0.0"
-source = "git+https://github.com/paritytech/substrate.git?branch=master#59da38b3a07b4ddf380ff9b01a5874fd883138a9"
 
 [[package]]
 name = "sp-std"
@@ -13894,7 +13888,7 @@ dependencies = [
  "ref-cast",
  "serde 1.0.147",
  "sp-debug-derive",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
 ]
 
 [[package]]
@@ -13907,7 +13901,7 @@ dependencies = [
  "sp-externalities",
  "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
  "sp-runtime-interface",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
 ]
 
 [[package]]
@@ -13922,7 +13916,7 @@ dependencies = [
  "sp-api",
  "sp-inherents",
  "sp-runtime",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
  "thiserror 1.0.37",
 ]
 
@@ -13932,7 +13926,7 @@ version = "5.0.0"
 source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28#ce10b9f29353e89fc3e59d447041bb29622def3f"
 dependencies = [
  "parity-scale-codec",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
  "tracing",
  "tracing-core",
  "tracing-subscriber",
@@ -13959,7 +13953,7 @@ dependencies = [
  "sp-core",
  "sp-inherents",
  "sp-runtime",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
  "sp-trie",
 ]
 
@@ -13973,7 +13967,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
  "thiserror 1.0.37",
  "trie-db",
  "trie-root",
@@ -13991,7 +13985,7 @@ dependencies = [
  "serde 1.0.147",
  "sp-core-hashing-proc-macro",
  "sp-runtime",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
  "sp-version-proc-macro",
  "thiserror 1.0.37",
 ]
@@ -14015,7 +14009,7 @@ dependencies = [
  "impl-trait-for-tuples",
  "log 0.4.17",
  "parity-scale-codec",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
  "wasmi",
  "wasmtime",
 ]
@@ -14171,7 +14165,7 @@ dependencies = [
  "sp-rpc",
  "sp-runtime",
  "sp-runtime-interface",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
  "sp-version",
  "thiserror 1.0.37",
  "ws",
@@ -14277,7 +14271,7 @@ dependencies = [
  "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
  "sp-runtime",
  "sp-state-machine",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
  "sp-trie",
  "trie-db",
 ]
@@ -14367,7 +14361,7 @@ version = "0.1.0"
 source = "git+https://github.com/integritee-network/pallets.git?branch=develop#ee5a5b8b4fabb520d75f18ad808251341eee4169"
 dependencies = [
  "common-primitives",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
  "substrate-fixed 0.5.9 (git+https://github.com/encointer/substrate-fixed?tag=v0.5.9)",
 ]
 
@@ -14382,7 +14376,7 @@ dependencies = [
  "serde 1.0.147",
  "sp-core",
  "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
 ]
 
 [[package]]
@@ -16006,7 +16000,7 @@ dependencies = [
  "sp-arithmetic",
  "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
  "sp-runtime",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
  "xcm",
  "xcm-executor",
 ]
@@ -16024,7 +16018,7 @@ dependencies = [
  "sp-core",
  "sp-io 6.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
  "sp-runtime",
- "sp-std 4.0.0 (git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.28)",
+ "sp-std",
  "xcm",
 ]
 

--- a/core-primitives/attestation-handler/src/attestation_handler.rs
+++ b/core-primitives/attestation-handler/src/attestation_handler.rs
@@ -98,7 +98,7 @@ pub trait AttestationHandler {
 }
 
 pub struct IasAttestationHandler<OCallApi> {
-	ocall_api: Arc<OCallApi>,
+	pub ocall_api: Arc<OCallApi>,
 }
 
 impl<OCallApi> AttestationHandler for IasAttestationHandler<OCallApi>
@@ -328,7 +328,7 @@ where
 		Ok(Vec::new())
 	}
 
-	fn make_ias_client_config() -> rustls::ClientConfig {
+	pub fn make_ias_client_config() -> rustls::ClientConfig {
 		let mut config = rustls::ClientConfig::new();
 
 		config.root_store.add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
@@ -418,7 +418,7 @@ where
 		self.parse_response_attn_report(&plaintext)
 	}
 
-	fn as_u32_le(&self, array: [u8; 4]) -> u32 {
+	pub fn as_u32_le(&self, array: [u8; 4]) -> u32 {
 		u32::from(array[0])
 			+ (u32::from(array[1]) << 8)
 			+ (u32::from(array[2]) << 16)
@@ -556,7 +556,7 @@ where
 		}
 	}
 
-	fn get_ias_api_key() -> EnclaveResult<String> {
+	pub fn get_ias_api_key() -> EnclaveResult<String> {
 		io::read_to_string(RA_API_KEY_FILE)
 			.map(|key| key.trim_end().to_owned())
 			.map_err(|e| EnclaveError::Other(e.into()))
@@ -584,7 +584,6 @@ fn decode_spid(hex_encoded_string: &str) -> SgxResult<sgx_spid_t> {
 
 #[cfg(feature = "test")]
 pub mod tests {
-
 	use super::*;
 
 	pub fn decode_spid_works() {

--- a/core-primitives/attestation-handler/src/attestation_handler.rs
+++ b/core-primitives/attestation-handler/src/attestation_handler.rs
@@ -336,7 +336,9 @@ where
 		//let sigrl_req = sigrl_arg.to_httpreq();
 		let ias_key = Self::get_ias_api_key()?;
 
-		let req = format!("GET {}{:08x} HTTP/1.1\r\nHOST: {}\r\nOcp-Apim-Subscription-Key: {}\r\nConnection: Close\r\n\r\n",
+		// GID: Base 16-encoded, encoded as a Big Endian integer.
+		let gid = hex::encode(gid.to_be_bytes());
+		let req = format!("GET {}{} HTTP/1.1\r\nHOST: {}\r\nOcp-Apim-Subscription-Key: {}\r\nConnection: Close\r\n\r\n",
 						  SIGRL_SUFFIX,
 						  gid,
 						  DEV_HOSTNAME,

--- a/core-primitives/enclave-api/ffi/src/lib.rs
+++ b/core-primitives/enclave-api/ffi/src/lib.rs
@@ -98,9 +98,14 @@ extern "C" {
 		unchecked_extrinsic: *mut u8,
 		unchecked_extrinsic_size: u32,
 		skip_ra: c_int,
+		linkable: c_int,
 	) -> sgx_status_t;
 
-	pub fn dump_ra_to_disk(eid: sgx_enclave_id_t, retval: *mut sgx_status_t) -> sgx_status_t;
+	pub fn dump_ra_to_disk(
+		eid: sgx_enclave_id_t,
+		retval: *mut sgx_status_t,
+		linkable: c_int,
+	) -> sgx_status_t;
 
 	pub fn test_main_entrance(eid: sgx_enclave_id_t, retval: *mut sgx_status_t) -> sgx_status_t;
 

--- a/enclave-runtime/Cargo.lock
+++ b/enclave-runtime/Cargo.lock
@@ -676,6 +676,7 @@ dependencies = [
  "frame-support",
  "frame-system",
  "hex 0.4.3",
+ "httparse",
  "ipfs-unixfs",
  "ita-exchange-oracle",
  "ita-sgx-runtime",

--- a/enclave-runtime/Cargo.toml
+++ b/enclave-runtime/Cargo.toml
@@ -141,6 +141,8 @@ sp-core = { default-features = false, features = ["full_crypto"], git = "https:/
 sp-runtime = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.28" }
 sp-std = { default-features = false, git = "https://github.com/paritytech/substrate.git", branch = "polkadot-v0.9.28" }
 
+httparse = { default-features = false, git = "https://github.com/integritee-network/httparse-sgx", branch = "sgx-experimental" }
+
 [patch.crates-io]
 env_logger = { git = "https://github.com/integritee-network/env_logger-sgx" }
 getrandom = { git = "https://github.com/integritee-network/getrandom-sgx", branch = "update-v2.3" }

--- a/enclave-runtime/Enclave.edl
+++ b/enclave-runtime/Enclave.edl
@@ -81,7 +81,8 @@ enclave {
 		public sgx_status_t perform_ra(
 			[in, size=w_url_size] uint8_t* w_url, uint32_t w_url_size,
 			[out, size=unchecked_extrinsic_size] uint8_t* unchecked_extrinsic, uint32_t unchecked_extrinsic_size,
-			int skip_ra
+			int skip_ra,
+			int linkable
 		);
 
 		public sgx_status_t update_market_data_xt(
@@ -90,7 +91,7 @@ enclave {
             [out, size=unchecked_extrinsic_size] uint8_t* unchecked_extrinsic, uint32_t unchecked_extrinsic_size
 		);
 
-		public sgx_status_t dump_ra_to_disk();
+		public sgx_status_t dump_ra_to_disk(int linkable);
 
 		public sgx_status_t run_state_provisioning_server(int fd, sgx_quote_sign_type_t quote_type, int skip_ra);
         public sgx_status_t request_state_provisioning(

--- a/enclave-runtime/src/test/mod.rs
+++ b/enclave-runtime/src/test/mod.rs
@@ -25,6 +25,7 @@ pub mod fixtures;
 pub mod ipfs_tests;
 pub mod mocks;
 pub mod on_chain_ocall_tests;
+pub mod ra_tests;
 pub mod sidechain_aura_tests;
 pub mod sidechain_event_tests;
 mod state_getter_tests;

--- a/enclave-runtime/src/test/ra_tests.rs
+++ b/enclave-runtime/src/test/ra_tests.rs
@@ -1,0 +1,62 @@
+/*
+	Copyright 2021 Integritee AG and Supercomputing Systems AG
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+use crate::{global_components::GLOBAL_ATTESTATION_HANDLER_COMPONENT, ocall::OcallApi};
+use itp_attestation_handler::{attestation_handler::SIGRL_SUFFIX, IasAttestationHandler, *};
+use itp_component_container::ComponentGetter;
+use itp_ocall_api::EnclaveAttestationOCallApi;
+use std::{
+	format,
+	io::{Read, Write},
+	net::TcpStream,
+	sync::Arc,
+	vec::Vec,
+};
+
+pub fn get_sigrl_from_intel_works() {
+	let attestation_handler = GLOBAL_ATTESTATION_HANDLER_COMPONENT.get().unwrap();
+
+	let init_quote = attestation_handler.ocall_api.sgx_init_quote().unwrap();
+	let epid_group_id = init_quote.1;
+	let eg_num = attestation_handler.as_u32_le(epid_group_id);
+
+	let config = IasAttestationHandler::<OcallApi>::make_ias_client_config();
+	let ias_socket = attestation_handler.ocall_api.get_ias_socket().unwrap();
+	let ias_key = IasAttestationHandler::<OcallApi>::get_ias_api_key().unwrap();
+
+	// GID: Base 16-encoded, encoded as a Big Endian integer.
+	let gid = hex::encode(eg_num.to_be_bytes());
+	let req = format!("GET {}{} HTTP/1.1\r\nHOST: {}\r\nOcp-Apim-Subscription-Key: {}\r\nConnection: Close\r\n\r\n",
+					  SIGRL_SUFFIX,
+					  gid,
+					  DEV_HOSTNAME,
+					  ias_key);
+
+	let dns_name = webpki::DNSNameRef::try_from_ascii_str(DEV_HOSTNAME).unwrap();
+	let mut sess = rustls::ClientSession::new(&Arc::new(config), dns_name);
+	let mut sock = TcpStream::new(ias_socket).unwrap();
+	let mut tls = rustls::Stream::new(&mut sess, &mut sock);
+
+	let _result = tls.write(req.as_bytes());
+	let mut plaintext = Vec::new();
+	let _ = tls.read_to_end(&mut plaintext);
+
+	let mut headers = [httparse::EMPTY_HEADER; 16];
+	let mut respp = httparse::Response::new(&mut headers);
+	let _ = respp.parse(&plaintext);
+
+	assert_eq!(respp.code, Some(200));
+}

--- a/enclave-runtime/src/test/tests_main.rs
+++ b/enclave-runtime/src/test/tests_main.rs
@@ -27,6 +27,7 @@ use crate::{
 			enclave_call_signer, test_setup, TestStf, TestStfExecutor, TestTopPoolAuthor,
 		},
 		mocks::types::TestStateKeyRepo,
+		ra_tests::get_sigrl_from_intel_works,
 		sidechain_aura_tests, sidechain_event_tests, state_getter_tests, top_pool_tests,
 	},
 	tls_ra,
@@ -97,6 +98,7 @@ pub extern "C" fn test_main_entrance() -> size_t {
 		test_create_block_and_confirmation_works,
 		// needs node to be running.. unit tests?
 		// test_ocall_worker_request,
+		get_sigrl_from_intel_works,
 		test_create_state_diff,
 		test_executing_call_updates_account_nonce,
 		test_call_set_update_parentchain_block,

--- a/service/src/cli.yml
+++ b/service/src/cli.yml
@@ -92,6 +92,10 @@ subcommands:
                 long: skip-ra
                 short: s
                 help: skip remote attestation. Set this flag if running enclave in SW mode
+            - linkable:
+                long: linkable
+                short: l
+                help: Set this flag if this SPID is associated with linkable quotes.
             - shard:
                 required: false
                 index: 1
@@ -122,6 +126,11 @@ subcommands:
                   long: skip-ra
                   short: s
                   help: skip remote attestation. Set this flag if running enclave in SW mode
+            - linkable:
+                long: linkable
+                short: l
+                help: Set this flag if this SPID is associated with linkable quotes.
+
     - shielding-key:
         about: Get the public RSA3072 key from the TEE to be used to encrypt requests
     - signing-key:

--- a/service/src/config.rs
+++ b/service/src/config.rs
@@ -175,6 +175,8 @@ impl From<&ArgMatches<'_>> for Config {
 pub struct RunConfig {
 	/// Skip remote attestation. Set this flag if running enclave in SW mode
 	pub skip_ra: bool,
+	/// Set linkable quote type. SGX_LINKABLE_SIGNATURE / SGX_UNLINKABLE_SIGNATURE
+	pub linkable: bool,
 	/// Set this flag if running in development mode to bootstrap enclave account on parentchain via //Alice.
 	pub dev: bool,
 	/// Request key and state provisioning from a peer worker.
@@ -188,6 +190,7 @@ pub struct RunConfig {
 impl From<&ArgMatches<'_>> for RunConfig {
 	fn from(m: &ArgMatches<'_>) -> Self {
 		let skip_ra = m.is_present("skip-ra");
+		let linkable = m.is_present("linkable");
 		let dev = m.is_present("dev");
 		let request_state = m.is_present("request-state");
 		let shard = m.value_of("shard").map(|s| s.to_string());
@@ -195,7 +198,7 @@ impl From<&ArgMatches<'_>> for RunConfig {
 			parse(i).unwrap_or_else(|e| panic!("teeracle-interval parsing error {:?}", e))
 		});
 
-		Self { skip_ra, dev, request_state, shard, teeracle_update_interval }
+		Self { skip_ra, linkable, dev, request_state, shard, teeracle_update_interval }
 	}
 }
 
@@ -324,6 +327,7 @@ mod test {
 			("request-state", Default::default()),
 			("dev", Default::default()),
 			("skip-ra", Default::default()),
+			("linkable", Default::default()),
 			("shard", Default::default()),
 			("teeracle-interval", Default::default()),
 		]);

--- a/service/src/sync_state.rs
+++ b/service/src/sync_state.rs
@@ -38,6 +38,7 @@ pub(crate) fn sync_state<
 	shard: &ShardIdentifier,
 	enclave_api: &E,
 	skip_ra: bool,
+	linkable: bool,
 ) {
 	// FIXME: we now assume that keys are equal for all shards.
 	let provider_url = match WorkerModeProvider::worker_mode() {
@@ -50,14 +51,13 @@ pub(crate) fn sync_state<
 
 	println!("Requesting state provisioning from worker at {}", &provider_url);
 
-	enclave_request_state_provisioning(
-		enclave_api,
-		sgx_quote_sign_type_t::SGX_UNLINKABLE_SIGNATURE,
-		&provider_url,
-		shard,
-		skip_ra,
-	)
-	.unwrap();
+	let mut sign_type = sgx_quote_sign_type_t::SGX_UNLINKABLE_SIGNATURE;
+	if linkable {
+		sign_type = sgx_quote_sign_type_t::SGX_LINKABLE_SIGNATURE;
+	}
+
+	enclave_request_state_provisioning(enclave_api, sign_type, &provider_url, shard, skip_ra)
+		.unwrap();
 	println!("[+] State provisioning successfully performed.");
 }
 


### PR DESCRIPTION
run `integritee-service` without flag `--skip-ra` to enable ra. 
and with the worker start command likes

* enable ra
* support linkable and unlikable quote type with flag `--linkable`
 
```shell
./integritee-service \
	--mu-ra-external-address "${worker_endpoint}" --mu-ra-port 3443 --untrusted-http-port 4545 --ws-external \
	--trusted-external-address "wss://${worker_endpoint}" --trusted-worker-port 2000 \
	--untrusted-external-address "ws://${worker_endpoint}" --untrusted-worker-port 2001 \
	--node-url "ws://${node_endpoint}" --node-port "${node_port}" \
	run --linkable --dev >"${ROOTDIR}"/log/worker1.log 2>&1 &
```

- [x] fix `get_sigrl_from_intel` 's param `gid` encoding format
- [x] fix enclave crash
- [x] add ra_tests
